### PR TITLE
Allow users to configure ROS output location

### DIFF
--- a/cloudwatch_logger/launch/cloudwatch_logger.launch
+++ b/cloudwatch_logger/launch/cloudwatch_logger.launch
@@ -3,8 +3,10 @@
     <arg name="node_name" default="cloudwatch_logger" />
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
     <arg name="config_file" default="" />
+    <!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
+    <arg name="output" default="log" />
         
-    <node name="$(arg node_name)" pkg="cloudwatch_logger" type="cloudwatch_logger">
+    <node name="$(arg node_name)" pkg="cloudwatch_logger" type="cloudwatch_logger" output="$(arg output)">
         <!-- If the caller specified a config file then load it here. -->
         <rosparam if="$(eval config_file!='')" command="load" file="$(arg config_file)"/>      
     </node>


### PR DESCRIPTION
This allows the user to send output to their screen instead of the default of 'log' when including the `cloudwatch_logger.launch` file inside their own launch file.

log is the default output value when it's not set (see http://wiki.ros.org/roslaunch/XML/node).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
