### PR TITLE
Use master branch for cloud extension dependencies

### DIFF
--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -1,0 +1,14 @@
+- git:
+  uri: https://github.com/aws-robotics/cloudwatch-common.git
+  local-name: cloudwatch-common
+  version: master
+
+- git:
+  uri: https://github.com/aws-robotics/utils-common.git
+  local-name: utils-common
+  version: master
+
+- git:
+  uri: https://github.com/aws-robotics/utils-ros1.git
+  local-name: utils-ros1
+  version: master

--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -1,14 +1,12 @@
 - git:
-  uri: https://github.com/aws-robotics/cloudwatch-common.git
-  local-name: cloudwatch-common
-  version: master
-
+    uri: https://github.com/aws-robotics/cloudwatch-common.git
+    local-name: cloudwatch-common
+    version: master
 - git:
-  uri: https://github.com/aws-robotics/utils-common.git
-  local-name: utils-common
-  version: master
-
+    uri: https://github.com/aws-robotics/utils-common.git
+    local-name: utils-common
+    version: master
 - git:
-  uri: https://github.com/aws-robotics/utils-ros1.git
-  local-name: utils-ros1
-  version: master
+    uri: https://github.com/aws-robotics/utils-ros1.git
+    local-name: utils-ros1
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ notifications:
       - ros-contributions@amazon.com
       - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
+  global:
+    - UPSTREAM_WORKSPACE=file
+    - ROSINSTALL_FILENAME=.rosinstall.master
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use master branch for cloud extension dependencies, so we can use the master branches of the packages for testing in travis before a bloom release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
