### PR TITLE
Get dependencies from rosdep instead of building from source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ notifications:
       - ros-contributions@amazon.com
 env:
   global:
-    - UPSTREAM_WORKSPACE=file
-    - ROSINSTALL_FILENAME=.rosinstall.master
+    # Uncomment to build  dependencies from source instead of rosdep
+    # - UPSTREAM_WORKSPACE=file
+    # - ROSINSTALL_FILENAME=.rosinstall.master
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu

--- a/cloudwatch_logger/package.xml
+++ b/cloudwatch_logger/package.xml
@@ -13,18 +13,18 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cloudwatch_logs_common</build_depend>
-  <build_depend>aws_common</build_depend>
-  <build_depend>aws_ros1_common</build_depend>
+  <build_depend version_lt='2.0.0'>cloudwatch_logs_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_ros1_common</build_depend>
   <build_depend>roscpp</build_depend>
 
-  <build_export_depend>cloudwatch_logs_common</build_export_depend>
-  <build_export_depend>aws_common</build_export_depend>
-  <build_export_depend>aws_ros1_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>cloudwatch_logs_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>aws_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>aws_ros1_common</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
 
-  <exec_depend>cloudwatch_logs_common</exec_depend>
-  <exec_depend>aws_common</exec_depend>
-  <exec_depend>aws_ros1_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>cloudwatch_logs_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>aws_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>aws_ros1_common</exec_depend>
   <exec_depend>roscpp</exec_depend>
 </package>


### PR DESCRIPTION
The release branch of cloud extension packages should take dependencies from rosdep(apt) instead of building from source.

*Issue #, if available:* N/A

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
