### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/cloudwatch_logger/package.xml
+++ b/cloudwatch_logger/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>cloudwatch_logger</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>CloudWatch Logger node for publishing logs to AWS CloudWatch Logs</description>
 
   <url>http://wiki.ros.org/cloudwatch_logger</url>


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
