### PR TITLE
Add missing rostest dependency to package.xml

### DIFF
--- a/cloudwatch_logger/package.xml
+++ b/cloudwatch_logger/package.xml
@@ -27,4 +27,6 @@
   <exec_depend>aws_common</exec_depend>
   <exec_depend>aws_ros1_common</exec_depend>
   <exec_depend>roscpp</exec_depend>
+  
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
In order to fix broken build: http://build.ros.org/job/Mbin_uB64__cloudwatch_logger__ubuntu_bionic_amd64__binary/2/console


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
