### PR TITLE
Adds a new parameter for a list of node names to ignore logs from.

### DIFF
--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -22,6 +22,11 @@ sub_to_rosout: true
 # default value is: empty list
 topics: []
 
+# list of node names to ignore logs from
+# e.g. To ignore all logs from a node named 'Talker' you would use the following configuration:
+#      ignore_nodes: ["/Talker"]
+ignore_nodes: ["/cloudwatch_logger", "/cloudwatch_metrics_collector"]
+
 # send logs to CloudWatch Logs based on log verbosity level
 # allowed values are: DEBUG, INFO, WARN, ERROR, FATAL
 # e.g. INFO level logs AND logs of log levels above(WARN, ERROR, FATAL) get sent to CloudWatch Logs

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -23,6 +23,7 @@
 #include <cloudwatch_logs_common/log_publisher.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Log.h>
+#include <unordered_set>
 
 namespace Aws {
 namespace CloudWatchLogs {
@@ -36,8 +37,9 @@ public:
    *
    * @param min_log_severity the minimum log severity level defined in the configuration file
    *                         logs with severity level equal or above get sent to CloudWatch Logs
+   * @param ignore_nodes The set of node names to ignore logs from
    */
-  explicit LogNode(int8_t min_log_severity);
+  explicit LogNode(int8_t min_log_severity, std::unordered_set<std::string> ignore_nodes);
 
   /**
    *  @brief Tears down a AWSCloudWatchLogNode object
@@ -77,6 +79,7 @@ private:
   const std::string FormatLogs(const rosgraph_msgs::Log::ConstPtr & log_msg);
   std::shared_ptr<Aws::CloudWatchLogs::LogManager> log_manager_;
   int8_t min_log_severity_;
+  std::unordered_set<std::string> ignore_nodes_;
 };
 
 }  // namespace Utils

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -19,6 +19,7 @@
 #include <aws_common/sdk_utils/parameter_reader.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Log.h>
+#include <unordered_set>
 
 namespace Aws {
 namespace CloudWatchLogs {
@@ -33,6 +34,7 @@ constexpr char kNodeParamSubscribeToRosoutKey[] = "sub_to_rosout";
 constexpr char kNodeParamLogGroupNameKey[] = "log_group_name";
 constexpr char kNodeParamLogTopicsListKey[] = "topics";
 constexpr char kNodeParamMinLogVerbosityKey[] = "min_log_verbosity";
+constexpr char kNodeParamIgnoreNodesKey[] = "ignore_nodes";
 
 constexpr char kNodeLogGroupNameDefaultValue[] = "ros_log_group";
 constexpr char kNodeLogStreamNameDefaultValue[] = "ros_log_stream";
@@ -117,6 +119,18 @@ Aws::AwsError ReadSubscriberList(
   boost::function<void(const rosgraph_msgs::Log::ConstPtr &)> callback,
   ros::NodeHandle & nh,
   std::vector<ros::Subscriber> & subscriptions);
+  
+/**
+ * Fetch the set of node names to ignore incoming logs from. 
+ * 
+ * @param parameter_reader to retrieve the parameters from.
+ * @param ignore_nodes all node names to ignore logs from are added here.
+ * @return an error code that indicates whether the parameter was read successfully or not, 
+ * as returned by \p parameter_reader
+ */
+Aws::AwsError ReadIgnoreNodesSet(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  std::unordered_set<std::string> & ignore_nodes);
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -27,7 +27,8 @@
 
 using namespace Aws::CloudWatchLogs::Utils;
 
-LogNode::LogNode(int8_t min_log_severity)
+LogNode::LogNode(int8_t min_log_severity, std::unordered_set<std::string> ignore_nodes) 
+    : ignore_nodes_(std::move(ignore_nodes))
 {
   this->log_manager_ = nullptr;
   this->min_log_severity_ = min_log_severity;
@@ -44,7 +45,7 @@ void LogNode::Initialize(const std::string & log_group, const std::string & log_
 
 void LogNode::RecordLogs(const rosgraph_msgs::Log::ConstPtr & log_msg)
 {
-  if (log_msg->name != "/cloudwatch_logger" && log_msg->name != "/cloudwatch_metrics_collector") {
+  if (0 == this->ignore_nodes_.count(log_msg->name)) {
     if (nullptr == this->log_manager_) {
       AWS_LOG_ERROR(__func__,
                     "Cannot publish CloudWatch logs with NULL CloudWatch LogManager instance.");

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -29,8 +29,7 @@ Aws::AwsError ReadPublishFrequency(
 {
   Aws::AwsError ret =
     parameter_reader->ReadParam(ParameterPath(kNodeParamPublishFrequencyKey), publish_frequency);
-  switch (ret)
-  {
+  switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       publish_frequency = kNodePublishFrequencyDefaultValue;
       AWS_LOGSTREAM_WARN(__func__,
@@ -54,8 +53,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
                            std::string & log_group)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogGroupNameKey), log_group);
-  switch (ret)
-  {
+  switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       log_group = kNodeLogGroupNameDefaultValue;
       AWS_LOGSTREAM_WARN(__func__,
@@ -78,8 +76,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
                             std::string & log_stream)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogStreamNameKey), log_stream);
-  switch (ret)
-  {
+  switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       log_stream = kNodeLogStreamNameDefaultValue;
       AWS_LOGSTREAM_WARN(__func__,
@@ -104,8 +101,7 @@ Aws::AwsError ReadSubscribeToRosout(
 {
   Aws::AwsError ret =
     parameter_reader->ReadParam(ParameterPath(kNodeParamSubscribeToRosoutKey), subscribe_to_rosout);
-  switch (ret)
-  {
+  switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       subscribe_to_rosout = kNodeSubscribeToRosoutDefaultValue;
       AWS_LOGSTREAM_WARN(
@@ -137,8 +133,7 @@ Aws::AwsError ReadMinLogVerbosity(
   std::string specified_verbosity;
   Aws::AwsError ret =
     parameter_reader->ReadParam(ParameterPath(kNodeParamMinLogVerbosityKey), specified_verbosity);
-  switch (ret)
-  {
+  switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       AWS_LOGSTREAM_WARN(__func__, "Log verbosity configuration not found, setting to default value: "
                                    << kNodeMinLogVerbosityDefaultValue);
@@ -184,8 +179,7 @@ Aws::AwsError ReadSubscriberList(
   std::vector<std::string> topics;
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogTopicsListKey), topics);
 
-  for (const std::string& topic : topics)
-  {
+  for (const std::string& topic : topics) {
     ros::Subscriber sub = nh.subscribe(topic, kNodeSubQueueSize, callback);
     AWS_LOGSTREAM_INFO(__func__, "Subscribing to topic: " << topic);
     subscriptions.push_back(sub);
@@ -198,6 +192,19 @@ Aws::AwsError ReadSubscriberList(
   return ret;
 }
 
+Aws::AwsError ReadIgnoreNodesSet(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  std::unordered_set<std::string> & ignore_nodes)
+{
+  std::vector<std::string> ignore_list;
+  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamIgnoreNodesKey), ignore_list);
+  
+  for (const std::string & node_name : ignore_list) {
+    ignore_nodes.emplace(node_name);
+  }
+  
+  return ret;
+}
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -198,9 +198,17 @@ Aws::AwsError ReadIgnoreNodesSet(
 {
   std::vector<std::string> ignore_list;
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamIgnoreNodesKey), ignore_list);
-  
-  for (const std::string & node_name : ignore_list) {
-    ignore_nodes.emplace(node_name);
+  switch (ret) {
+    case Aws::AwsError::AWS_ERR_NOT_FOUND:
+      break;
+    case Aws::AwsError::AWS_ERR_OK:
+      for (const std::string & node_name : ignore_list) {
+        ignore_nodes.emplace(node_name);
+      }
+      break;
+    default:
+      AWS_LOGSTREAM_ERROR(__func__, 
+        "Error " << ret << " retrieving retrieving list of nodes to ignore.");
   }
   
   return ret;

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -16,10 +16,11 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws_common/sdk_utils/client_configuration_provider.h>
 #include <cloudwatch_logger/log_node.h>
+#include <cloudwatch_logger/log_node_param_helper.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Log.h>
 #include <iostream>
-#include <cloudwatch_logger/log_node_param_helper.h>
+#include <unordered_set>
 
 using namespace Aws::CloudWatchLogs::Utils;
 
@@ -39,6 +40,7 @@ int main(int argc, char ** argv)
   bool subscribe_to_rosout;
   int8_t min_log_verbosity;
   std::vector<ros::Subscriber> subscriptions;
+  std::unordered_set<std::string> ignore_nodes;
 
   ros::NodeHandle nh;
 
@@ -51,13 +53,14 @@ int main(int argc, char ** argv)
   ReadLogStream(parameter_reader, log_stream);
   ReadSubscribeToRosout(parameter_reader, subscribe_to_rosout);
   ReadMinLogVerbosity(parameter_reader, min_log_verbosity);
+  ReadIgnoreNodesSet(parameter_reader, ignore_nodes);
 
   // configure aws settings
   Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);
   Aws::Client::ClientConfiguration config = client_config_provider.GetClientConfiguration();
   Aws::SDKOptions sdk_options;
 
-  Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity);
+  Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);
   cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options);
 
   // callback function


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/20

*Description of changes:*
Inside of the cloudwatch_logger node we were hard coding the name of two nodes that we wanted to filter logs from. These two nodes were the cloudwatch_logger node and the cloudwatch_metrics_collector node. This prevented the logger node from pushing its own logs to CloudWatch, which could be very noisy. The problem with hardcoding these node names is that it causes the user to be unable to rename the node when they run it and still get the filtering. 

This changes adds a new parameter that allows the user to specify a list of node names that they want to ignore logs for. This will allow the user to manually specify whatever nodes they don't want to ship logs for. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
