### PR TITLE
Offline Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Most users won't need to touch these parameters, they are useful if you want fin
 | file_prefix | A prefix to add to each offline storage file so they're easier to identify later | *string* | cwlog |
 | file_extension | The extension for all offline storage files | *string* | .log |
 | maximum_file_size | The maximum size each offline storage file in KB | *int* | 1024 |
+| stream_max_queue_size | The maximum number of batches in the queue to stream to CloudWatch. If this queue is full subsequent batches of logs will be written to disk. | *int* | 3 |
 
 ## Node
 

--- a/README.md
+++ b/README.md
@@ -136,16 +136,29 @@ An example launch file called `sample_application.launch` is provided.
 ## Configuration File and Parameters
 An example configuration file called `sample_configuration.yaml` is provided. When the parameters are absent in the ROS parameter server, default values are used, thus all parameters are optional. See table below for details.
 
-| Parameter Name | Description | Type | Allowed Values |
-| -------------- | ----------- | ---- | -------------- |
-| sub_to_rosout  | Whether to subscribe to *rosout_agg* topic | *bool* | true/false |
-| publish_frequency | Log publishing frequency in seconds | *double* | number |
-| log_group_name | AWS CloudWatch log group name | *std::string* | 'string'<br/>*note*: Log group names must be unique within a region foran AWS account |
-| log_stream_name | AWS CloudWatch log stream name | *std::string* | 'string'<br/>*note*: The : (colon) and * (asterisk) characters are not allowed |
-| topics | A list of topics to get logs from (excluding `rosout_agg`) | *std::vector<std::string>* | ['string', 'string', 'string'] |
-| ignore_nodes | A list of  of node names to ignore logs from | *std::vector<std::string>* | ['string', 'string', 'string'] |
-| min_log_verbosity| The minimum log severity for sending logs selectively to AWS CloudWatch Logs, log messages with a severity lower than `min_log_verbosity` will be ignored | *std::string* | DEBUG/INFO/WARN/ERROR/FATAL |
-| aws_client_configuration | AWS region configuration | *std::string* | *region*: "us-west-2"/"us-east-1"/"us-east-2"/etc. |
+| Parameter Name | Description | Type | Allowed Values | Default |
+| -------------- | ----------- | ---- | -------------- | ------------ |
+| sub_to_rosout  | Whether to subscribe to *rosout_agg* topic | *bool* | true/false | true |
+| publish_frequency | Log publishing frequency in seconds | *double* | number | 5.0 |
+| log_group_name | AWS CloudWatch log group name | *std::string* | 'string'<br/>*note*: Log group names must be unique within a region foran AWS account | ros_log_group |
+| log_stream_name | AWS CloudWatch log stream name | *std::string* | 'string'<br/>*note*: The : (colon) and * (asterisk) characters are not allowed | ros_log_stream |
+| topics | A list of topics to get logs from (excluding `rosout_agg`) | *std::vector<std::string>* | ['string', 'string', 'string'] | `[]` |
+| min_log_verbosity| The minimum log severity for sending logs selectively to AWS CloudWatch Logs, log messages with a severity lower than `min_log_verbosity` will be ignored | *std::string* | DEBUG/INFO/WARN/ERROR/FATAL | DEBUG |
+| storage_directory | The location where all offline metrics will be stored | *string* | string | ~/.ros/cwlogs/ |
+| storage_limit | The maximum size of all offline storage files in KB. Once this limit is reached offline logs will start to be deleted oldest first. | *int* | number | 1048576 |
+| aws_client_configuration | AWS region configuration | *std::string* | *region*: "us-west-2"/"us-east-1"/"us-east-2"/etc. | region: us-west-2 |
+
+### Advanced Configuration Parameters
+Most users won't need to touch these parameters, they are useful if you want fine grained control over how your metrics are stored offline and uploaded to CloudWatch. 
+
+| Parameter Name | Description | Type | Default |
+| ------------- | -----------------------------------------------------------| ------------- | ------------ |
+| batch_max_queue_size | The maximum number metrics items to add to the CloudWatch upload queue before they start to be written to disk | *int* | 1024 |
+| batch_trigger_publish_size | Only publish metrics to CloudWatch when there are this many items in the queue. When this is set the publishing of metrics on a constant timer is disabled. This must be smaller than batch_max_queue_size | *int* | 64 |
+| file_upload_batch_size | When streaming metrics from disk to CloudWatch it will pull this many metric items into each batch | *int* | 50 |
+| file_prefix | A prefix to add to each offline storage file so they're easier to identify later | *string* | cwlog |
+| file_extension | The extension for all offline storage files | *string* | .log |
+| maximum_file_size | The maximum size each offline storage file in KB | *int* | 1024 |
 
 
 ## Performance and Benchmark Results

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ _Note: If building the master branch instead of a release branch you may need to
 ## Launch Files
 An example launch file called `sample_application.launch` is provided.
 
-
 ## Usage
 
 ### Run the node
@@ -149,32 +148,17 @@ An example configuration file called `sample_configuration.yaml` is provided. Wh
 | aws_client_configuration | AWS region configuration | *std::string* | *region*: "us-west-2"/"us-east-1"/"us-east-2"/etc. | region: us-west-2 |
 
 ### Advanced Configuration Parameters
-Most users won't need to touch these parameters, they are useful if you want fine grained control over how your metrics are stored offline and uploaded to CloudWatch. 
+Most users won't need to touch these parameters, they are useful if you want fine grained control over how your logs are stored offline and uploaded to CloudWatch. 
 
 | Parameter Name | Description | Type | Default |
 | ------------- | -----------------------------------------------------------| ------------- | ------------ |
-| batch_max_queue_size | The maximum number metrics items to add to the CloudWatch upload queue before they start to be written to disk | *int* | 1024 |
-| batch_trigger_publish_size | Only publish metrics to CloudWatch when there are this many items in the queue. When this is set the publishing of metrics on a constant timer is disabled. This must be smaller than batch_max_queue_size | *int* | 64 |
-| file_upload_batch_size | When streaming metrics from disk to CloudWatch it will pull this many metric items into each batch | *int* | 50 |
+| batch_max_queue_size | The maximum number logs to add to the CloudWatch upload queue before they start to be written to disk | *int* | 1024 |
+| batch_trigger_publish_size | Only publish logs to CloudWatch when there are this many items in the queue. When this is set the publishing of logs on a constant timer is disabled. This must be smaller than batch_max_queue_size | *int* | 64 |
+| file_max_queue_size | The max number of batches in the queue, each of size file_upload_batch_size, when reading and uploading from offline storage files | *int* | 5 |
+| file_upload_batch_size | The size of each batch of logs in the queue, when reading and uploading from offline storage files | *int* | 50 |
 | file_prefix | A prefix to add to each offline storage file so they're easier to identify later | *string* | cwlog |
 | file_extension | The extension for all offline storage files | *string* | .log |
 | maximum_file_size | The maximum size each offline storage file in KB | *int* | 1024 |
-
-
-## Performance and Benchmark Results
-We evaluated the performance of this node by runnning the followning scenario on a Raspberry Pi 3 Model B:
-- Launch a baseline graph containing the talker and listener nodes from the [roscpp_tutorials package](https://wiki.ros.org/roscpp_tutorials), plus two additional nodes that collect CPU and memory usage statistics. Allow the nodes to run for 60 seconds.
-- Launch the Amazon CloudWatch Logs node using the launch file `example.launch` as described above. Allow the nodes to run for 180 seconds.
-- Terminate the Amazon CloudWatch Logs node, and allow the remaining nodes to run for 60 seconds.
-
-The following graph shows the CPU usage during that scenario. The 1 minute average CPU usage starts at 9.25% during the launch of the baseline graph, and stabilizes at 4.5%. When we launch the `cloudwatch_logger` node around second 60 the 1 minute average CPU increases up to a peak of 9.5%. After that initial peak, the CPU lowers to around 5% while the `cloudwatch_logger` node keeps sending the messages sent by the talker node to the AWS CloudWatch Logs service.
-
-![cpu](wiki/images/cpu.svg)
-
-The following graph shows the memory usage during that scenario. We start with a memory usage of 368 MB that increases to a peak of 412 MB (+11.96%) when the `cloudwatch_logger` node starts running, and stabilizes to 394 (+7%) while the node keeps running. The memory usage goes back to 368 MB after stopping the node.
-
-![memory](wiki/images/memory.svg)
-
 
 ## Node
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ This node will require the following AWS account IAM role permissions:
 - `logs:CreateLogStream`
 - `logs:CreateLogGroup`
 
+TODO
+
+Ensure your region is set.
+
+If desired to test credentials intall the aws cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+
+Test your credentials / setup with the following: aws cloudwatch put-metric-data --namespace "Test Metrics" --metric-data file://metric.json --debug
+
+where metric.json is 
+
+[
+  {
+    "MetricName": "New Posts",
+    "Timestamp": "Thursday, June 6, 2019 10:28:20 AM",
+    "Value": 8.50,
+    "Unit": "Count"
+  }
+]
+
+Note: replace the date with the current date.
+
 ### Binaries
 On Ubuntu you can install the latest version of this package using the following command
 

--- a/cloudwatch_logger/CMakeLists.txt
+++ b/cloudwatch_logger/CMakeLists.txt
@@ -4,6 +4,8 @@ project(cloudwatch_logger)
 ## Compile as C++11, supported in ROS Kinetic and newer
 set(CMAKE_CXX_STANDARD 11)
 
+find_package(dataflow_lite REQUIRED)
+find_package(file_management REQUIRED)
 find_package(cloudwatch_logs_common REQUIRED)
 
 ## Find catkin macros and libraries
@@ -26,6 +28,13 @@ catkin_package()
 
 ## Declare a C++ executable
 add_library(${PROJECT_NAME}_lib SHARED src/log_node.cpp src/log_node_param_helper.cpp)
+
+target_include_directories(${PROJECT_NAME}_lib PUBLIC include ${catkin_INCLUDE_DIRS} ${dataflow_lite_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${cloudwatch_logs_common_LIBRARIES})
+
+target_include_directories(${PROJECT_NAME}_lib PUBLIC include ${catkin_INCLUDE_DIRS} ${file_management_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${file_management_LIBRARIES})
+
 target_include_directories(${PROJECT_NAME}_lib PUBLIC include ${catkin_INCLUDE_DIRS} ${cloudwatch_logs_common_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${cloudwatch_logs_common_LIBRARIES})
 
@@ -111,7 +120,7 @@ if(CATKIN_ENABLE_TESTING)
       include
       ${catkin_INCLUDE_DIRS}
       ${cloudwatch_logger_INCLUDE_DIRS}
-    )   
+    )
     target_link_libraries(test_log_node_param_helper
       ${PROJECT_NAME}_lib
       ${catkin_LIBRARIES}

--- a/cloudwatch_logger/CMakeLists.txt
+++ b/cloudwatch_logger/CMakeLists.txt
@@ -1,6 +1,32 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cloudwatch_logger)
 
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# Enable strict compiler flags if possible.
+include(CheckCXXCompilerFlag)
+# Removed -Wmissing-declarations until gmock is ignored
+# removed -Werror=pedantic until ros.h is fixed
+set(FLAGS -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings)
+foreach(FLAG ${FLAGS})
+  check_cxx_compiler_flag(${FLAG} R${FLAG})
+  if(${R${FLAG}})
+    set(WARNING_CXX_FLAGS "${WARNING_CXX_FLAGS} ${FLAG}")
+  endif()
+endforeach()
+
+if(NOT DEFINED CXX_DISABLE_WERROR)
+  set(WARNING_CXX_FLAGS "-Werror ${WARNING_CXX_FLAGS}")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_CXX_FLAGS}")
+
 ## Compile as C++11, supported in ROS Kinetic and newer
 set(CMAKE_CXX_STANDARD 11)
 

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -34,36 +34,31 @@ ignore_nodes: ["/cloudwatch_logger", "/cloudwatch_metrics_collector"]
 # default value is: DEBUG == logs of all log verbosity levels get sent to CloudWatch Logs
 min_log_verbosity: DEBUG
 
-### Options related to file uploading ###
-
-# How many unique logs to send to CloudWatch in each upload
-file_upload_batch_size: 5
-
-# Maximum number of files in the upload queue when reading from disk
-file_max_queue_size: 10
-
-# Maximum number of files in the upload queue when streaming live logs
-# from the robot to CloudWatch logs
-stream_max_queue_size: 10
+### Options related to uploading to CloudWatch ###
 
 # Maximum number of items to add to the upload queue.
 # If this limit is reached the logs will start to be written to disk.
-batch_max_queue_size: 512
+batch_max_queue_size: 1024
 
-# Once this many log items are in the queue
-# a cloudwatch log spublish will be triggered.
-# If this is not set the logs will be published on a constant timer
-# regardless of the queue size.
+# Once this many log items are in the queue a CloudWatch log publish will be triggered.
+# If this is not set the logs will be published on a constant timer regardless of the queue size.
 # batch_trigger_publish_size: 64
 
-### Options related to offline file management ###
+# How many unique logs to send to CloudWatch in each upload
+file_upload_batch_size: 50
 
-# The absolute path to a folder that all
-# offline logs will be stored in
-storage_directory: "~/.ros/storage/"
+# Maximum number of files in the upload queue when reading from disk
+file_max_queue_size: 2
+
+# Maximum number of files in the upload queue when streaming live logs from the node to CloudWatch logs
+stream_max_queue_size: 20
+
+### Options related to offline file management ###
+# When this node goes offline or cannot talk to CloudWatch it will store all metrics in text files on disk
+# Then when it's back online it will upload them to CloudWatch. These are settings related to this feature.
 
 # This prefix will be added to all offline log files
-file_prefix: "my-app"
+file_prefix: "cwlog"
 
 # This file extension will be used for all offline log files
 file_extension: ".log"
@@ -71,8 +66,11 @@ file_extension: ".log"
 # The maximum size of each file in offline storage in KB
 maximum_file_size: 1024
 
+# The absolute path to a folder that all offline logs will be stored in
+storage_directory: "~/.ros/cwlogs/"
+
 # The maximum size of all files in offline storage in KB
-storage_limit: 65536
+storage_limit: 1048576
 
 # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
 # provided configuration when initializing the client.

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -44,8 +44,12 @@ aws_client_configuration:
 
   # Values that determine the length of time, in milliseconds, to wait before timing out a request. You can increase
   # this value if you need to transfer large files, such as in Amazon S3 or Amazon CloudFront.
-  connect_timeout_ms: 9000
-  request_timeout_ms: 9000
+  connect_timeout_ms: 2000
+  request_timeout_ms: 2000
 
   # The number of retries for connecting to AWS Services
   max_retries: 10
+
+  # The retry strategy used when connection requests are attempted. If set to true then requests
+  # will fail fast, otherwise will use an exponential retry algorithm defined by the AWS SDK.
+  no_retry_strategy: true

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -36,32 +36,43 @@ min_log_verbosity: DEBUG
 
 ### Options related to file uploading ###
 
-file_upload_batch_size: 40
+# How many unique logs to send to CloudWatch in each upload
+file_upload_batch_size: 5
 
-# Maximum number of files in the queue when reading from disk
-file_max_queue_size: 3
+# Maximum number of files in the upload queue when reading from disk
+file_max_queue_size: 10
 
-# Maximum number of files in the queue when streaming
-stream_max_queue_size: 30
+# Maximum number of files in the upload queue when streaming live logs
+# from the robot to CloudWatch logs
+stream_max_queue_size: 10
 
+# Maximum number of items to add to the upload queue.
+# If this limit is reached the logs will start to be written to disk.
 batch_max_queue_size: 512
 
-batch_trigger_publish_size: 2048
-
-
+# Once this many log items are in the queue
+# a cloudwatch log spublish will be triggered.
+# If this is not set the logs will be published on a constant timer
+# regardless of the queue size.
+# batch_trigger_publish_size: 64
 
 ### Options related to offline file management ###
 
+# The absolute path to a folder that all
+# offline logs will be stored in
 storage_directory: "~/.ros/storage/"
 
-file_prefix: "MyAppName"
+# This prefix will be added to all offline log files
+file_prefix: "my-app"
 
-file_extension: ".pewpew"
+# This file extension will be used for all offline log files
+file_extension: ".log"
 
-# The maximum size of each file in offline storage
-maximum_file_size: 42
+# The maximum size of each file in offline storage in KB
+maximum_file_size: 1024
 
-storage_limit: 5500
+# The maximum size of all files in offline storage in KB
+storage_limit: 65536
 
 # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
 # provided configuration when initializing the client.

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -87,9 +87,6 @@ aws_client_configuration:
   connect_timeout_ms: 2000
   request_timeout_ms: 2000
 
-  # The number of retries for connecting to AWS Services
-  max_retries: 10
-
   # The retry strategy used when connection requests are attempted. If set to true then requests
   # will fail fast, otherwise will use an exponential retry algorithm defined by the AWS SDK.
   no_retry_strategy: true

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -34,38 +34,6 @@ ignore_nodes: ["/cloudwatch_logger", "/cloudwatch_metrics_collector"]
 # default value is: DEBUG == logs of all log verbosity levels get sent to CloudWatch Logs
 min_log_verbosity: DEBUG
 
-### Options related to uploading to CloudWatch ###
-
-# Maximum number of items to add to the upload queue.
-# If this limit is reached the logs will start to be written to disk.
-batch_max_queue_size: 1024
-
-# Once this many log items are in the queue a CloudWatch log publish will be triggered.
-# If this is not set the logs will be published on a constant timer regardless of the queue size.
-# batch_trigger_publish_size: 64
-
-# How many unique logs to send to CloudWatch in each upload
-file_upload_batch_size: 50
-
-# Maximum number of files in the upload queue when reading from disk
-file_max_queue_size: 2
-
-# Maximum number of files in the upload queue when streaming live logs from the node to CloudWatch logs
-stream_max_queue_size: 20
-
-### Options related to offline file management ###
-# When this node goes offline or cannot talk to CloudWatch it will store all metrics in text files on disk
-# Then when it's back online it will upload them to CloudWatch. These are settings related to this feature.
-
-# This prefix will be added to all offline log files
-file_prefix: "cwlog"
-
-# This file extension will be used for all offline log files
-file_extension: ".log"
-
-# The maximum size of each file in offline storage in KB
-maximum_file_size: 1024
-
 # The absolute path to a folder that all offline logs will be stored in
 storage_directory: "~/.ros/cwlogs/"
 

--- a/cloudwatch_logger/config/sample_configuration.yaml
+++ b/cloudwatch_logger/config/sample_configuration.yaml
@@ -34,6 +34,35 @@ ignore_nodes: ["/cloudwatch_logger", "/cloudwatch_metrics_collector"]
 # default value is: DEBUG == logs of all log verbosity levels get sent to CloudWatch Logs
 min_log_verbosity: DEBUG
 
+### Options related to file uploading ###
+
+file_upload_batch_size: 40
+
+# Maximum number of files in the queue when reading from disk
+file_max_queue_size: 3
+
+# Maximum number of files in the queue when streaming
+stream_max_queue_size: 30
+
+batch_max_queue_size: 512
+
+batch_trigger_publish_size: 2048
+
+
+
+### Options related to offline file management ###
+
+storage_directory: "~/.ros/storage/"
+
+file_prefix: "MyAppName"
+
+file_extension: ".pewpew"
+
+# The maximum size of each file in offline storage
+maximum_file_size: 42
+
+storage_limit: 5500
+
 # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
 # provided configuration when initializing the client.
 aws_client_configuration:

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -23,12 +23,14 @@
 #include <ros/ros.h>
 #include <rosgraph_msgs/Log.h>
 #include <unordered_set>
+#include <std_srvs/Trigger.h>
+#include <std_srvs/Empty.h>
 
 namespace Aws {
 namespace CloudWatchLogs {
 namespace Utils {
 
-class LogNode
+class LogNode : public Service
 {
 public:
   /**
@@ -58,6 +60,9 @@ public:
                   const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options, 
                   std::shared_ptr<LogServiceFactory> log_service_factory = std::make_shared<LogServiceFactory>());
 
+  bool start() override;
+  bool shutdown() override;
+
   /**
    * @brief Emits RecordLog using the log manager
    *
@@ -72,6 +77,15 @@ public:
    * @param timer A ros timer
    */
   void TriggerLogPublisher(const ros::TimerEvent &);
+
+  /**
+   * Return a Trigger response detailing the LogService status.
+   *
+   * @param request input request
+   * @param response output response
+   * @return true if the request was handled successfully, false otherwise
+   */
+  bool checkIfOnline(std_srvs::Trigger::Request& request, std_srvs::Trigger::Response& response);
 
 private:
   bool ShouldSendToCloudWatchLogs(const int8_t log_severity_level);

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -18,9 +18,8 @@
 #include <aws_common/sdk_utils/client_configuration_provider.h>
 #include <aws_ros1_common/sdk_utils/logging/aws_ros_logger.h>
 #include <aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h>
-#include <cloudwatch_logs_common/log_manager.h>
-#include <cloudwatch_logs_common/log_manager_factory.h>
-#include <cloudwatch_logs_common/log_publisher.h>
+#include <cloudwatch_logs_common/log_service.h>
+#include <cloudwatch_logs_common/log_service_factory.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Log.h>
 #include <unordered_set>
@@ -53,11 +52,11 @@ public:
    * @param log_stream log stream name
    * @param config aws client configuration object
    * @param sdk_options aws sdk options
-   * @param log_manager_factory optional log manager factory
+   * @param log_service_factory optional log manager factory
    */
   void Initialize(const std::string & log_group, const std::string & log_stream,
                   const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options, 
-                  std::shared_ptr<LogManagerFactory> log_manager_factory = std::make_shared<LogManagerFactory>()); 
+                  std::shared_ptr<LogServiceFactory> log_service_factory = std::make_shared<LogServiceFactory>());
 
   /**
    * @brief Emits RecordLog using the log manager
@@ -77,7 +76,7 @@ public:
 private:
   bool ShouldSendToCloudWatchLogs(const int8_t log_severity_level);
   const std::string FormatLogs(const rosgraph_msgs::Log::ConstPtr & log_msg);
-  std::shared_ptr<Aws::CloudWatchLogs::LogManager> log_manager_;
+  std::shared_ptr<Aws::CloudWatchLogs::LogService> log_service_;
   int8_t min_log_severity_;
   std::unordered_set<std::string> ignore_nodes_;
 };

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -80,7 +80,7 @@ public:
   void TriggerLogPublisher(const ros::TimerEvent &);
 
   /**
-   * Return a Trigger response detailing the LogService status.
+   * Return a Trigger response detailing the LogService online status.
    *
    * @param request input request
    * @param response output response

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -57,7 +57,8 @@ public:
    * @param log_service_factory optional log manager factory
    */
   void Initialize(const std::string & log_group, const std::string & log_stream,
-                  const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options, 
+                  const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
+                  const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
                   std::shared_ptr<LogServiceFactory> log_service_factory = std::make_shared<LogServiceFactory>());
 
   bool start() override;

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -42,6 +42,7 @@ constexpr char kNodeParamFileUploadBatchSize[] = "file_upload_batch_size";
 constexpr char kNodeParamFileMaxQueueSize[] = "file_max_queue_size";
 constexpr char kNodeParamBatchMaxQueueSize[] = "batch_max_queue_size";
 constexpr char kNodeParamBatchTriggerPublishSize[] = "batch_trigger_publish_size";
+constexpr char kNodeParamStreamMaxQueueSize[] = "stream_max_queue_size";
 
 /** Configuration params for Aws::FileManagement::FileManagerStrategyOptions **/
 constexpr char kNodeParamFilePrefix[] = "file_prefix";

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -38,11 +38,11 @@ constexpr char kNodeParamMinLogVerbosityKey[] = "min_log_verbosity";
 constexpr char kNodeParamIgnoreNodesKey[] = "ignore_nodes";
 
 /** Configuration params for Aws::DataFlow::UploaderOptions **/
-const std::string kNodeParamFileUploadBatchSize = "file_upload_batch_size";
-const std::string kNodeParamFileMaxQueueSize = "file_max_queue_size";
-const std::string kNodeParamStreamMaxQueueSize = "stream_max_queue_size";
-const std::string kNodeParamBatchMaxQueueSize = "batch_max_queue_size";
-const std::string kNodeParamBatchTriggerPublishSize = "batch_trigger_publish_size";
+constexpr char kNodeParamFileUploadBatchSize[] = "file_upload_batch_size";
+constexpr char kNodeParamFileMaxQueueSize[] = "file_max_queue_size";
+constexpr char kNodeParamStreamMaxQueueSize[] = "stream_max_queue_size";
+constexpr char kNodeParamBatchMaxQueueSize[] = "batch_max_queue_size";
+constexpr char kNodeParamBatchTriggerPublishSize[] = "batch_trigger_publish_size";
 
 /** Configuration params for Aws::FileManagement::FileManagerStrategyOptions **/
 constexpr char kNodeParamFilePrefix[] = "file_prefix";

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -147,39 +147,89 @@ Aws::AwsError ReadIgnoreNodesSet(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   std::unordered_set<std::string> & ignore_nodes);
 
-Aws::AwsError ReadCloudwatchOptions(
+/**
+ * Fetch the options related to cloudwatch uploading and offline file mangement
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param cloudwatch_options a struct of uploader and file_manager options
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
+Aws::AwsError ReadCloudWatchOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options);
 
-void ReadUploaderOptions(
+/**
+ * Fetch the options related to cloudwatch log uploading
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param uploader_options a struct of uploader options
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
+Aws::AwsError ReadUploaderOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options);
 
+/**
+ * Fetch a single size_t option related to cloudwatch log uploading
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param option_key the parameter key to read
+ * @param default_value a default value if the parameter doesn't exist or is unreadble
+ * @param option_value the value for this option
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
 Aws::AwsError ReadUploaderOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);
 
-void ReadFileManagerStrategyOptions(
+/**
+ * Fetch the options related to cloudwatch offline file management
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param file_manager_strategy_options a struct of file management options
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
+Aws::AwsError ReadFileManagerStrategyOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  Aws::FileManagement::FileManagerStrategyOptions & uploader_options);
+  Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options);
 
+/**
+ * Fetch a single string option related to cloudwatch offline file management
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param option_key the parameter key to read
+ * @param default_value a default value if the parameter doesn't exist or is unreadble
+ * @param option_value the string value for this option
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
 Aws::AwsError ReadFileManagerStrategyOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value);
 
+/**
+ * Fetch a single size_t option related to cloudwatch offline file management
+ *
+ * @param parameter_reader to retrieve the parameters from
+ * @param option_key the parameter key to read
+ * @param default_value a default value if the parameter doesn't exist or is unreadble
+ * @param option_value the size_t value for this option
+ * @return an error code that indicates whether the parameter was read successfully or not,
+ * as returned by \p parameter_reader
+ */
 Aws::AwsError ReadFileManagerStrategyOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);
-
-
-
-
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -40,7 +40,6 @@ constexpr char kNodeParamIgnoreNodesKey[] = "ignore_nodes";
 /** Configuration params for Aws::DataFlow::UploaderOptions **/
 constexpr char kNodeParamFileUploadBatchSize[] = "file_upload_batch_size";
 constexpr char kNodeParamFileMaxQueueSize[] = "file_max_queue_size";
-constexpr char kNodeParamStreamMaxQueueSize[] = "stream_max_queue_size";
 constexpr char kNodeParamBatchMaxQueueSize[] = "batch_max_queue_size";
 constexpr char kNodeParamBatchTriggerPublishSize[] = "batch_trigger_publish_size";
 
@@ -155,7 +154,7 @@ Aws::AwsError ReadIgnoreNodesSet(
  * @return an error code that indicates whether the parameter was read successfully or not,
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadCloudWatchOptions(
+void ReadCloudWatchOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options);
 
@@ -167,25 +166,9 @@ Aws::AwsError ReadCloudWatchOptions(
  * @return an error code that indicates whether the parameter was read successfully or not,
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadUploaderOptions(
+void ReadUploaderOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options);
-
-/**
- * Fetch a single size_t option related to cloudwatch log uploading
- *
- * @param parameter_reader to retrieve the parameters from
- * @param option_key the parameter key to read
- * @param default_value a default value if the parameter doesn't exist or is unreadble
- * @param option_value the value for this option
- * @return an error code that indicates whether the parameter was read successfully or not,
- * as returned by \p parameter_reader
- */
-Aws::AwsError ReadUploaderOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  const std::string & option_key,
-  const size_t & default_value,
-  size_t & option_value);
 
 /**
  * Fetch the options related to cloudwatch offline file management
@@ -195,12 +178,12 @@ Aws::AwsError ReadUploaderOption(
  * @return an error code that indicates whether the parameter was read successfully or not,
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadFileManagerStrategyOptions(
+void ReadFileManagerStrategyOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options);
 
 /**
- * Fetch a single string option related to cloudwatch offline file management
+ * Fetch a single string option
  *
  * @param parameter_reader to retrieve the parameters from
  * @param option_key the parameter key to read
@@ -209,14 +192,14 @@ Aws::AwsError ReadFileManagerStrategyOptions(
  * @return an error code that indicates whether the parameter was read successfully or not,
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadFileManagerStrategyOption(
+void ReadOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value);
 
 /**
- * Fetch a single size_t option related to cloudwatch offline file management
+ * Fetch a single size_t option
  *
  * @param parameter_reader to retrieve the parameters from
  * @param option_key the parameter key to read
@@ -225,7 +208,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
  * @return an error code that indicates whether the parameter was read successfully or not,
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadFileManagerStrategyOption(
+void ReadOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const size_t & default_value,

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cloudwatch_logs_common/cloudwatch_options.h>
 #include <aws_common/sdk_utils/aws_error.h>
 #include <aws_common/sdk_utils/parameter_reader.h>
 #include <ros/ros.h>
@@ -35,6 +36,20 @@ constexpr char kNodeParamLogGroupNameKey[] = "log_group_name";
 constexpr char kNodeParamLogTopicsListKey[] = "topics";
 constexpr char kNodeParamMinLogVerbosityKey[] = "min_log_verbosity";
 constexpr char kNodeParamIgnoreNodesKey[] = "ignore_nodes";
+
+/** Configuration params for Aws::DataFlow::UploaderOptions **/
+const std::string kNodeParamFileUploadBatchSize = "file_upload_batch_size";
+const std::string kNodeParamFileMaxQueueSize = "file_max_queue_size";
+const std::string kNodeParamStreamMaxQueueSize = "stream_max_queue_size";
+const std::string kNodeParamBatchMaxQueueSize = "batch_max_queue_size";
+const std::string kNodeParamBatchTriggerPublishSize = "batch_trigger_publish_size";
+
+/** Configuration params for Aws::FileManagement::FileManagerStrategyOptions **/
+constexpr char kNodeParamFilePrefix[] = "file_prefix";
+constexpr char kNodeParamStorageDirectory[] = "storage_directory";
+constexpr char kNodeParamFileExtension[] = "file_extension";
+constexpr char kNodeParamMaximumFileSize[] = "maximum_file_size";
+constexpr char kNodeParamStorageLimit[] = "storage_limit";
 
 constexpr char kNodeLogGroupNameDefaultValue[] = "ros_log_group";
 constexpr char kNodeLogStreamNameDefaultValue[] = "ros_log_stream";
@@ -131,6 +146,40 @@ Aws::AwsError ReadSubscriberList(
 Aws::AwsError ReadIgnoreNodesSet(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   std::unordered_set<std::string> & ignore_nodes);
+
+Aws::AwsError ReadCloudwatchOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options);
+
+void ReadUploaderOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::DataFlow::UploaderOptions & uploader_options);
+
+Aws::AwsError ReadUploaderOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string & option_key,
+  const size_t & default_value,
+  size_t & option_value);
+
+void ReadFileManagerStrategyOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::FileManagement::FileManagerStrategyOptions & uploader_options);
+
+Aws::AwsError ReadFileManagerStrategyOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string & option_key,
+  const std::string & default_value,
+  std::string & option_value);
+
+Aws::AwsError ReadFileManagerStrategyOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string & option_key,
+  const size_t & default_value,
+  size_t & option_value);
+
+
+
+
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/launch/cloudwatch_logger.launch
+++ b/cloudwatch_logger/launch/cloudwatch_logger.launch
@@ -4,7 +4,7 @@
     <!-- If a config file argument is provided by the caller then we will load it into the node's namespace -->
     <arg name="config_file" default="" />
     <!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
-    <arg name="output" default="log" />
+    <arg name="output" default="screen" />
         
     <node name="$(arg node_name)" pkg="cloudwatch_logger" type="cloudwatch_logger" output="$(arg output)">
         <!-- If the caller specified a config file then load it here. -->

--- a/cloudwatch_logger/launch/sample_application.launch
+++ b/cloudwatch_logger/launch/sample_application.launch
@@ -4,10 +4,12 @@
     <!-- Custom Nodes would be launched here -->
 
     <arg name="config_file" default="$(find cloudwatch_logger)/config/sample_configuration.yaml"/>
+    <arg name="output" default="log" />
 
     <include file="$(find cloudwatch_logger)/launch/cloudwatch_logger.launch" >
         <!-- The configuration can either be passed in using the "config_file" parameter or by using a rosparam tag
                 to load the config into the parameter server -->
         <arg name="config_file" value="$(arg config_file)"/>
+        <arg name="output" value="$(arg output)"/>
     </include>
 </launch>

--- a/cloudwatch_logger/package.xml
+++ b/cloudwatch_logger/package.xml
@@ -22,11 +22,16 @@
   <build_export_depend>aws_common</build_export_depend>
   <build_export_depend>aws_ros1_common</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>std_srvs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
 
   <exec_depend>cloudwatch_logs_common</exec_depend>
   <exec_depend>aws_common</exec_depend>
   <exec_depend>aws_ros1_common</exec_depend>
   <exec_depend>roscpp</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
 
   <test_depend>gtest</test_depend>
   <test_depend>google-mock</test_depend>

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -55,7 +55,6 @@ void LogNode::RecordLogs(const rosgraph_msgs::Log::ConstPtr & log_msg)
     }
     if (ShouldSendToCloudWatchLogs(log_msg->level)) {
       this->log_service_->batchData(FormatLogs(log_msg));
-      this->log_service_->batchData(std::string("this is a test message along for the ride"));
     }
   }
 }

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -49,6 +49,8 @@ void LogNode::Initialize(const std::string & log_group, const std::string & log_
 
 bool LogNode::checkIfOnline(std_srvs::Trigger::Request& request, std_srvs::Trigger::Response& response) {
 
+  AWS_LOGSTREAM_DEBUG(__func__, "received request " << request);
+
   if (!this->log_service_) {
     response.success = false;
     response.message = "The LogService is not initialized";
@@ -62,17 +64,20 @@ bool LogNode::checkIfOnline(std_srvs::Trigger::Request& request, std_srvs::Trigg
 }
 
 bool LogNode::start() {
+  bool is_started = true;
   if (this->log_service_) {
-    return this->log_service_->start();
+    is_started &= this->log_service_->start();
   }
-  return false;
+  is_started &= Service::start();
+  return is_started;
 }
 
 bool LogNode::shutdown() {
+  bool is_shutdown = Service::shutdown();
   if (this->log_service_) {
-    return this->log_service_->shutdown();
+    is_shutdown &= this->log_service_->shutdown();
   }
-  return false;
+  return is_shutdown;
 }
 
 void LogNode::RecordLogs(const rosgraph_msgs::Log::ConstPtr & log_msg)

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -41,9 +41,10 @@ LogNode::~LogNode() { this->log_service_ = nullptr; }
 
 void LogNode::Initialize(const std::string & log_group, const std::string & log_stream,
                          const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
+                         const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
                          std::shared_ptr<LogServiceFactory> factory)
 {
-  this->log_service_ = factory->CreateLogService(log_group, log_stream, config, sdk_options);
+  this->log_service_ = factory->CreateLogService(log_group, log_stream, config, sdk_options, cloudwatch_options);
 }
 
 bool LogNode::checkIfOnline(std_srvs::Trigger::Request& request, std_srvs::Trigger::Response& response) {

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -263,6 +263,13 @@ void ReadUploaderOptions(
     Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size,
     uploader_options.batch_trigger_publish_size
   );
+
+  ReadOption(
+    parameter_reader,
+    kNodeParamStreamMaxQueueSize,
+    Aws::DataFlow::kDefaultUploaderOptions.stream_max_queue_size,
+    uploader_options.stream_max_queue_size
+  );
 }
 
 void ReadFileManagerStrategyOptions(

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -34,7 +34,7 @@ Aws::AwsError ReadPublishFrequency(
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       publish_frequency = kNodePublishFrequencyDefaultValue;
-      AWS_LOGSTREAM_WARN(__func__,
+      AWS_LOGSTREAM_INFO(__func__,
                          "Publish frequency configuration not found, setting to default value: "
                          << kNodePublishFrequencyDefaultValue);
       break;
@@ -58,7 +58,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       log_group = kNodeLogGroupNameDefaultValue;
-      AWS_LOGSTREAM_WARN(__func__,
+      AWS_LOGSTREAM_INFO(__func__,
                        "Log group name configuration not found, setting to default value: "
                          << kNodeLogGroupNameDefaultValue);
       break;
@@ -81,7 +81,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       log_stream = kNodeLogStreamNameDefaultValue;
-      AWS_LOGSTREAM_WARN(__func__,
+      AWS_LOGSTREAM_INFO(__func__,
                          "Log stream name configuration not found, setting to default value: "
                          << kNodeLogStreamNameDefaultValue);
       break;
@@ -106,7 +106,7 @@ Aws::AwsError ReadSubscribeToRosout(
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       subscribe_to_rosout = kNodeSubscribeToRosoutDefaultValue;
-      AWS_LOGSTREAM_WARN(
+      AWS_LOGSTREAM_INFO(
       __func__,
       "Whether to subscribe to rosout_agg topic configuration not found, setting to default value: "
         << kNodeSubscribeToRosoutDefaultValue);
@@ -137,7 +137,7 @@ Aws::AwsError ReadMinLogVerbosity(
     parameter_reader->ReadParam(ParameterPath(kNodeParamMinLogVerbosityKey), specified_verbosity);
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
-      AWS_LOGSTREAM_WARN(__func__, "Log verbosity configuration not found, setting to default value: "
+      AWS_LOGSTREAM_INFO(__func__, "Log verbosity configuration not found, setting to default value: "
                                    << kNodeMinLogVerbosityDefaultValue);
       break;
     case Aws::AwsError::AWS_ERR_OK:
@@ -158,7 +158,7 @@ Aws::AwsError ReadMinLogVerbosity(
         AWS_LOG_INFO(__func__, "Log verbosity is set to FATAL.");
       } else {
         ret = AwsError::AWS_ERR_PARAM;
-        AWS_LOGSTREAM_WARN(__func__,
+        AWS_LOGSTREAM_INFO(__func__,
                           "Log verbosity configuration not valid, setting to default value: "
                            << kNodeMinLogVerbosityDefaultValue);
       }
@@ -216,7 +216,7 @@ Aws::AwsError ReadIgnoreNodesSet(
   return ret;
 }
 
-Aws::AwsError ReadCloudWatchOptions(
+void ReadCloudWatchOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options) {
 
@@ -230,11 +230,9 @@ Aws::AwsError ReadCloudWatchOptions(
     uploader_options,
     file_manager_strategy_options
   };
-
-  return Aws::AwsError::AWS_ERR_OK;
 }
 
-Aws::AwsError ReadUploaderOptions(
+void ReadUploaderOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options) {
 
@@ -254,13 +252,6 @@ Aws::AwsError ReadUploaderOptions(
 
   ReadUploaderOption(
     parameter_reader,
-    kNodeParamStreamMaxQueueSize,
-    Aws::DataFlow::kDefaultUploaderOptions.stream_max_queue_size,
-    uploader_options.stream_max_queue_size
-  );
-
-  ReadUploaderOption(
-    parameter_reader,
     kNodeParamBatchMaxQueueSize,
     Aws::DataFlow::kDefaultUploaderOptions.batch_max_queue_size,
     uploader_options.batch_max_queue_size
@@ -272,70 +263,44 @@ Aws::AwsError ReadUploaderOptions(
     Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size,
     uploader_options.batch_trigger_publish_size
   );
-
-  return Aws::AwsError::AWS_ERR_OK;
 }
 
-Aws::AwsError ReadUploaderOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  const std::string &option_key,
-  const size_t &default_value,
-  size_t & option_value) {
-
-  int param_value = 0;
-  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), param_value);
-  switch (ret) {
-    case Aws::AwsError::AWS_ERR_NOT_FOUND:
-      option_value = default_value;
-      AWS_LOGSTREAM_WARN(__func__,
-                         option_key << " parameter not found, setting to default value: " << default_value);
-      break;
-    case Aws::AwsError::AWS_ERR_OK:
-      option_value = (size_t)param_value;
-      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
-      break;
-    default:
-      AWS_LOGSTREAM_ERROR(__func__,
-        "Error " << ret << " retrieving option " << option_value << ", setting to default value: " << default_value);
-      option_value = default_value;
-      break;
-  }
-  return ret;
-}
-
-Aws::AwsError ReadFileManagerStrategyOptions(
+void ReadFileManagerStrategyOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options) {
 
-  ReadFileManagerStrategyOption(parameter_reader,
+  ReadOption(
+    parameter_reader,
     kNodeParamStorageDirectory,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_directory,
     file_manager_strategy_options.storage_directory);
 
-  ReadFileManagerStrategyOption(parameter_reader,
+  ReadOption(
+    parameter_reader,
     kNodeParamFilePrefix,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_prefix,
     file_manager_strategy_options.file_prefix);
 
-  ReadFileManagerStrategyOption(parameter_reader,
+  ReadOption(
+    parameter_reader,
     kNodeParamFileExtension,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_extension,
     file_manager_strategy_options.file_extension);
 
-  ReadFileManagerStrategyOption(parameter_reader,
+  ReadOption(
+    parameter_reader,
     kNodeParamMaximumFileSize,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.maximum_file_size_in_kb,
     file_manager_strategy_options.maximum_file_size_in_kb);
 
-  ReadFileManagerStrategyOption(parameter_reader,
+  ReadOption(
+    parameter_reader,
     kNodeParamStorageLimit,
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
     file_manager_strategy_options.storage_limit_in_kb);
-
-  return Aws::AwsError::AWS_ERR_OK;
 }
 
-Aws::AwsError ReadFileManagerStrategyOption(
+void ReadOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
@@ -344,7 +309,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       option_value = default_value;
-      AWS_LOGSTREAM_WARN(__func__,
+      AWS_LOGSTREAM_INFO(__func__,
                          option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
@@ -355,10 +320,9 @@ Aws::AwsError ReadFileManagerStrategyOption(
       AWS_LOGSTREAM_ERROR(__func__,
         "Error " << ret << " retrieving option " << option_key << ", setting to default value: " << default_value);
   }
-  return ret;
 }
 
-Aws::AwsError ReadFileManagerStrategyOption(
+void ReadOption(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
@@ -368,7 +332,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
   switch (ret) {
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       option_value = default_value;
-      AWS_LOGSTREAM_WARN(__func__,
+      AWS_LOGSTREAM_INFO(__func__,
                          option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
@@ -380,7 +344,6 @@ Aws::AwsError ReadFileManagerStrategyOption(
       AWS_LOGSTREAM_ERROR(__func__,
         "Error " << ret << " retrieving option " << option_key << ", setting to default value: " << default_value);
   }
-  return ret;
 }
 
 }  // namespace Utils

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -340,7 +340,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
                            << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
-    AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
+      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:
       option_value = default_value;

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -216,7 +216,7 @@ Aws::AwsError ReadIgnoreNodesSet(
   return ret;
 }
 
-Aws::AwsError ReadCloudwatchOptions(
+Aws::AwsError ReadCloudWatchOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options) {
 
@@ -230,9 +230,11 @@ Aws::AwsError ReadCloudwatchOptions(
     uploader_options,
     file_manager_strategy_options
   };
+
+  return Aws::AwsError::AWS_ERR_OK;
 }
 
-void ReadUploaderOptions(
+Aws::AwsError ReadUploaderOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options) {
 
@@ -271,6 +273,7 @@ void ReadUploaderOptions(
     uploader_options.batch_trigger_publish_size
   );
 
+  return Aws::AwsError::AWS_ERR_OK;
 }
 
 Aws::AwsError ReadUploaderOption(
@@ -282,20 +285,25 @@ Aws::AwsError ReadUploaderOption(
   int param_value = 0;
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), param_value);
   switch (ret) {
+    case Aws::AwsError::AWS_ERR_NOT_FOUND:
+      option_value = default_value;
+      AWS_LOGSTREAM_WARN(__func__,
+                         option_key << " parameter not found, setting to default value: " << default_value);
+      break;
     case Aws::AwsError::AWS_ERR_OK:
       option_value = (size_t)param_value;
-      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to " << option_value);
+      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:
       AWS_LOGSTREAM_ERROR(__func__,
-                                 "Error " << ret << " retrieving option " << option_value << ". Using default value of " << default_value);
+        "Error " << ret << " retrieving option " << option_value << ", setting to default value: " << default_value);
       option_value = default_value;
       break;
   }
   return ret;
 }
 
-void ReadFileManagerStrategyOptions(
+Aws::AwsError ReadFileManagerStrategyOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options) {
 
@@ -324,6 +332,7 @@ void ReadFileManagerStrategyOptions(
     Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
     file_manager_strategy_options.storage_limit_in_kb);
 
+  return Aws::AwsError::AWS_ERR_OK;
 }
 
 Aws::AwsError ReadFileManagerStrategyOption(
@@ -336,8 +345,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       option_value = default_value;
       AWS_LOGSTREAM_WARN(__func__,
-                         option_key << " parameter not found, setting to default value: "
-                           << default_value);
+                         option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
       AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
@@ -345,8 +353,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
     default:
       option_value = default_value;
       AWS_LOGSTREAM_ERROR(__func__,
-                          "Error " << ret << " retrieving option " << option_key << ", setting to default value: "
-                                   << default_value);
+        "Error " << ret << " retrieving option " << option_key << ", setting to default value: " << default_value);
   }
   return ret;
 }
@@ -362,8 +369,7 @@ Aws::AwsError ReadFileManagerStrategyOption(
     case Aws::AwsError::AWS_ERR_NOT_FOUND:
       option_value = default_value;
       AWS_LOGSTREAM_WARN(__func__,
-                         option_key << " parameter not found, setting to default value: "
-                           << default_value);
+                         option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
       option_value = (size_t)return_value;
@@ -372,17 +378,10 @@ Aws::AwsError ReadFileManagerStrategyOption(
     default:
       option_value = default_value;
       AWS_LOGSTREAM_ERROR(__func__,
-                          "Error " << ret << " retrieving option " << option_key << ", setting to default value: "
-                                   << default_value);
+        "Error " << ret << " retrieving option " << option_key << ", setting to default value: " << default_value);
   }
   return ret;
 }
-
-
-
-
-
-
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -236,28 +236,28 @@ void ReadUploaderOptions(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options) {
 
-  ReadUploaderOption(
+  ReadOption(
     parameter_reader,
     kNodeParamFileUploadBatchSize,
     Aws::DataFlow::kDefaultUploaderOptions.file_upload_batch_size,
     uploader_options.file_upload_batch_size
   );
 
-  ReadUploaderOption(
+  ReadOption(
     parameter_reader,
     kNodeParamFileMaxQueueSize,
     Aws::DataFlow::kDefaultUploaderOptions.file_max_queue_size,
     uploader_options.file_max_queue_size
   );
 
-  ReadUploaderOption(
+  ReadOption(
     parameter_reader,
     kNodeParamBatchMaxQueueSize,
     Aws::DataFlow::kDefaultUploaderOptions.batch_max_queue_size,
     uploader_options.batch_max_queue_size
   );
 
-  ReadUploaderOption(
+  ReadOption(
     parameter_reader,
     kNodeParamBatchTriggerPublishSize,
     Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size,

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -16,6 +16,8 @@
 #include <cloudwatch_logger/log_node_param_helper.h>
 #include <aws_common/sdk_utils/parameter_reader.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <cloudwatch_logs_common/cloudwatch_options.h>
+
 
 using namespace Aws::Client;
 
@@ -213,6 +215,174 @@ Aws::AwsError ReadIgnoreNodesSet(
   
   return ret;
 }
+
+Aws::AwsError ReadCloudwatchOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options) {
+
+  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::FileManagement::FileManagerStrategyOptions file_manager_strategy_options;
+
+  ReadUploaderOptions(parameter_reader, uploader_options);
+  ReadFileManagerStrategyOptions(parameter_reader, file_manager_strategy_options);
+
+  cloudwatch_options = {
+    uploader_options,
+    file_manager_strategy_options
+  };
+}
+
+void ReadUploaderOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::DataFlow::UploaderOptions & uploader_options) {
+
+  ReadUploaderOption(
+    parameter_reader,
+    kNodeParamFileUploadBatchSize,
+    Aws::DataFlow::kDefaultUploaderOptions.file_upload_batch_size,
+    uploader_options.file_upload_batch_size
+  );
+
+  ReadUploaderOption(
+    parameter_reader,
+    kNodeParamFileMaxQueueSize,
+    Aws::DataFlow::kDefaultUploaderOptions.file_max_queue_size,
+    uploader_options.file_max_queue_size
+  );
+
+  ReadUploaderOption(
+    parameter_reader,
+    kNodeParamStreamMaxQueueSize,
+    Aws::DataFlow::kDefaultUploaderOptions.stream_max_queue_size,
+    uploader_options.stream_max_queue_size
+  );
+
+  ReadUploaderOption(
+    parameter_reader,
+    kNodeParamBatchMaxQueueSize,
+    Aws::DataFlow::kDefaultUploaderOptions.batch_max_queue_size,
+    uploader_options.batch_max_queue_size
+  );
+
+  ReadUploaderOption(
+    parameter_reader,
+    kNodeParamBatchTriggerPublishSize,
+    Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size,
+    uploader_options.batch_trigger_publish_size
+  );
+
+}
+
+Aws::AwsError ReadUploaderOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string &option_key,
+  const size_t &default_value,
+  size_t & option_value) {
+
+  int param_value = 0;
+  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), param_value);
+  switch (ret) {
+    case Aws::AwsError::AWS_ERR_OK:
+      option_value = (size_t)param_value;
+      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to " << option_value);
+      break;
+    default:
+      AWS_LOGSTREAM_ERROR(__func__,
+                                 "Error " << ret << " retrieving option " << option_value << ". Using default value of " << default_value);
+      option_value = default_value;
+      break;
+  }
+  return ret;
+}
+
+void ReadFileManagerStrategyOptions(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options) {
+
+  ReadFileManagerStrategyOption(parameter_reader,
+    kNodeParamStorageDirectory,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_directory,
+    file_manager_strategy_options.storage_directory);
+
+  ReadFileManagerStrategyOption(parameter_reader,
+    kNodeParamFilePrefix,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_prefix,
+    file_manager_strategy_options.file_prefix);
+
+  ReadFileManagerStrategyOption(parameter_reader,
+    kNodeParamFileExtension,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_extension,
+    file_manager_strategy_options.file_extension);
+
+  ReadFileManagerStrategyOption(parameter_reader,
+    kNodeParamMaximumFileSize,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.maximum_file_size_in_kb,
+    file_manager_strategy_options.maximum_file_size_in_kb);
+
+  ReadFileManagerStrategyOption(parameter_reader,
+    kNodeParamStorageLimit,
+    Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
+    file_manager_strategy_options.storage_limit_in_kb);
+
+}
+
+Aws::AwsError ReadFileManagerStrategyOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string & option_key,
+  const std::string & default_value,
+  std::string & option_value) {
+  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), option_value);
+  switch (ret) {
+    case Aws::AwsError::AWS_ERR_NOT_FOUND:
+      option_value = default_value;
+      AWS_LOGSTREAM_WARN(__func__,
+                         option_key << " parameter not found, setting to default value: "
+                           << default_value);
+      break;
+    case Aws::AwsError::AWS_ERR_OK:
+    AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
+      break;
+    default:
+      option_value = default_value;
+      AWS_LOGSTREAM_ERROR(__func__,
+                          "Error " << ret << " retrieving option " << option_key << ", setting to default value: "
+                                   << default_value);
+  }
+  return ret;
+}
+
+Aws::AwsError ReadFileManagerStrategyOption(
+  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::string & option_key,
+  const size_t & default_value,
+  size_t & option_value) {
+  int return_value = 0;
+  Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(option_key), return_value);
+  switch (ret) {
+    case Aws::AwsError::AWS_ERR_NOT_FOUND:
+      option_value = default_value;
+      AWS_LOGSTREAM_WARN(__func__,
+                         option_key << " parameter not found, setting to default value: "
+                           << default_value);
+      break;
+    case Aws::AwsError::AWS_ERR_OK:
+      option_value = (size_t)return_value;
+      AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
+      break;
+    default:
+      option_value = default_value;
+      AWS_LOGSTREAM_ERROR(__func__,
+                          "Error " << ret << " retrieving option " << option_key << ", setting to default value: "
+                                   << default_value);
+  }
+  return ret;
+}
+
+
+
+
+
+
 
 }  // namespace Utils
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -23,6 +23,8 @@
 #include <unordered_set>
 #include <string>
 
+#include <cloudwatch_logs_common/cloudwatch_options.h>
+
 using namespace Aws::CloudWatchLogs::Utils;
 
 constexpr char kNodeName[] = "cloudwatch_logger";
@@ -42,6 +44,7 @@ int main(int argc, char ** argv)
   int8_t min_log_verbosity;
   std::vector<ros::Subscriber> subscriptions;
   std::unordered_set<std::string> ignore_nodes;
+  Aws::CloudWatchLogs::CloudWatchOptions cloudwatch_options;
 
   ros::NodeHandle nh;
 
@@ -55,6 +58,8 @@ int main(int argc, char ** argv)
   ReadSubscribeToRosout(parameter_reader, subscribe_to_rosout);
   ReadMinLogVerbosity(parameter_reader, min_log_verbosity);
   ReadIgnoreNodesSet(parameter_reader, ignore_nodes);
+
+  ReadCloudwatchOptions(parameter_reader, cloudwatch_options);
 
   // configure aws settings
   Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -89,10 +89,15 @@ int main(int argc, char ** argv)
   ReadSubscriberList(subscribe_to_rosout, parameter_reader, callback, nh, subscriptions);
   AWS_LOGSTREAM_INFO(__func__, "Initialized " << kNodeName << ".");
 
-  // a ros timer that triggers log publisher to publish periodically
-  ros::Timer timer =
-    nh.createTimer(ros::Duration(publish_frequency),
-                   &Aws::CloudWatchLogs::Utils::LogNode::TriggerLogPublisher, &cloudwatch_logger);
+  bool publish_when_size_reached = cloudwatch_options.uploader_options.batch_trigger_publish_size
+    != Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size;
+
+  // Publish on a timer if we are not publishing on a size limit.
+  if (!publish_when_size_reached) {
+    ros::Timer timer =
+      nh.createTimer(ros::Duration(publish_frequency),
+                     &Aws::CloudWatchLogs::Utils::LogNode::TriggerLogPublisher, &cloudwatch_logger);
+  }
   ros::spin();
   AWS_LOGSTREAM_INFO(__func__, "Shutting down " << kNodeName << ".");
   cloudwatch_logger.shutdown();

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -68,7 +68,6 @@ int main(int argc, char ** argv)
   Aws::SDKOptions sdk_options;
   sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
 
-  // todo batch by size (pass option)
   Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);
   cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options, cloudwatch_options);
 
@@ -92,16 +91,20 @@ int main(int argc, char ** argv)
   bool publish_when_size_reached = cloudwatch_options.uploader_options.batch_trigger_publish_size
     != Aws::DataFlow::kDefaultUploaderOptions.batch_trigger_publish_size;
 
+  ros::Timer timer;
   // Publish on a timer if we are not publishing on a size limit.
   if (!publish_when_size_reached) {
-    ros::Timer timer =
+    timer =
       nh.createTimer(ros::Duration(publish_frequency),
                      &Aws::CloudWatchLogs::Utils::LogNode::TriggerLogPublisher, &cloudwatch_logger);
   }
+
   ros::spin();
+
   AWS_LOGSTREAM_INFO(__func__, "Shutting down " << kNodeName << ".");
   cloudwatch_logger.shutdown();
   Aws::Utils::Logging::ShutdownAWSLogging();
   ros::shutdown();
+
   return 0;
 }

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char ** argv)
   ReadMinLogVerbosity(parameter_reader, min_log_verbosity);
   ReadIgnoreNodesSet(parameter_reader, ignore_nodes);
 
-  ReadCloudwatchOptions(parameter_reader, cloudwatch_options);
+  ReadCloudWatchOptions(parameter_reader, cloudwatch_options);
 
   // configure aws settings
   Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char ** argv)
 
   // todo batch by size (pass option)
   Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);
-  cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options);
+  cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options, cloudwatch_options);
 
   ros::ServiceServer service = nh.advertiseService(
     "testLoggerNode",

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -71,10 +71,9 @@ int main(int argc, char ** argv)
   Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);
   cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options, cloudwatch_options);
 
-  ros::ServiceServer service = nh.advertiseService(
-    "testLoggerNode",
-    &Aws::CloudWatchLogs::Utils::LogNode::checkIfOnline,
-    &cloudwatch_logger);
+  ros::ServiceServer service = nh.advertiseService(kNodeName,
+                                                   &Aws::CloudWatchLogs::Utils::LogNode::checkIfOnline,
+                                                   &cloudwatch_logger);
 
   cloudwatch_logger.start();
 
@@ -96,7 +95,8 @@ int main(int argc, char ** argv)
   if (!publish_when_size_reached) {
     timer =
       nh.createTimer(ros::Duration(publish_frequency),
-                     &Aws::CloudWatchLogs::Utils::LogNode::TriggerLogPublisher, &cloudwatch_logger);
+                     &Aws::CloudWatchLogs::Utils::LogNode::TriggerLogPublisher,
+                     &cloudwatch_logger);
   }
 
   ros::spin();

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -21,6 +21,7 @@
 #include <rosgraph_msgs/Log.h>
 #include <iostream>
 #include <unordered_set>
+#include <string>
 
 using namespace Aws::CloudWatchLogs::Utils;
 
@@ -58,15 +59,19 @@ int main(int argc, char ** argv)
   // configure aws settings
   Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);
   Aws::Client::ClientConfiguration config = client_config_provider.GetClientConfiguration();
-  Aws::SDKOptions sdk_options;
 
+  Aws::SDKOptions sdk_options;
+  sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+
+  // todo batch by size
   Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);
-  cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options);
+  cloudwatch_logger.Initialize(log_group, log_stream, config, sdk_options); // todo why not make this a service as well?
 
   // callback function
   boost::function<void(const rosgraph_msgs::Log::ConstPtr &)> callback;
   callback = [&cloudwatch_logger](const rosgraph_msgs::Log::ConstPtr & log_msg) -> void {
     cloudwatch_logger.RecordLogs(log_msg);
+
   };
 
   // subscribe to additional topics, if any

--- a/cloudwatch_logger/src/main.cpp
+++ b/cloudwatch_logger/src/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
   Aws::Client::ClientConfiguration config = client_config_provider.GetClientConfiguration();
 
   Aws::SDKOptions sdk_options;
-  sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Debug;
+  sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
 
   // todo batch by size
   Aws::CloudWatchLogs::Utils::LogNode cloudwatch_logger(min_log_verbosity, ignore_nodes);

--- a/cloudwatch_logger/test/log_node_param_helper_test.cpp
+++ b/cloudwatch_logger/test/log_node_param_helper_test.cpp
@@ -254,6 +254,7 @@ TEST_F(LogNodeParamHelperFixture, TestReadReadMinLogVerbosity)
 
 AwsError MockReadParamAddStringToList(const ParameterPath & param_path, std::vector<std::string> & out)
 {
+  (void)param_path;
   out.emplace_back("String1");
   return AwsError::AWS_ERR_OK;
 }

--- a/cloudwatch_logger/test/log_node_test.cpp
+++ b/cloudwatch_logger/test/log_node_test.cpp
@@ -17,8 +17,8 @@
 #include <gmock/gmock.h>
 
 #include <cloudwatch_logger/log_node.h>
-#include <cloudwatch_logs_common/log_manager.h>
-#include <cloudwatch_logs_common/log_manager_factory.h>
+#include <cloudwatch_logs_common/log_batcher.h>
+#include <cloudwatch_logs_common/log_service_factory.h>
 #include <rosgraph_msgs/Log.h>
 
 using namespace Aws::CloudWatchLogs;
@@ -31,208 +31,208 @@ using ::testing::StrEq;
 using ::testing::Eq;
 using ::testing::InSequence;
 
-class LogManagerFactoryMock : public LogManagerFactory
-{
-  public:
-    MOCK_METHOD4(CreateLogManager, 
-      std::shared_ptr<LogManager>(
-        const std::string & log_group, const std::string & log_stream,
-        const Aws::Client::ClientConfiguration & client_config, const Aws::SDKOptions & sdk_options
-      )
-    );
-};
-
-class LogManagerMock : public LogManager
-{
-public: 
-  LogManagerMock(): LogManager(nullptr) {}
-
-  MOCK_METHOD1(RecordLog, ROSCloudWatchLogsErrors(const std::string & log_msg_formatted));
-  MOCK_METHOD0(Service, ROSCloudWatchLogsErrors());
-};
-
-class LogNodeFixture : public ::testing::Test
-{
-protected:
-  std::shared_ptr<LogManagerMock> log_manager_ = std::make_shared<LogManagerMock>();
-  std::shared_ptr<LogManagerFactoryMock> log_manager_factory_ = std::make_shared<LogManagerFactoryMock>();
-
-  rosgraph_msgs::Log log_message_;
-  
-  void SetUp() override 
-  {
-    log_message_.name = "NjhkYjRkZjQ3N2Qw";
-    log_message_.msg = "ZjQxOGE2MWM5MTFkMWNjMDVkMGY2OTZm";
-    log_message_.level = rosgraph_msgs::Log::DEBUG;
-  }
-
-  std::shared_ptr<LogNode> build_test_subject(int8_t severity_level = rosgraph_msgs::Log::DEBUG,
-      std::unordered_set<std::string> ignore_nodes = std::unordered_set<std::string>()) 
-  {
-    return std::make_shared<LogNode>(severity_level, ignore_nodes);
-  }
-
-  rosgraph_msgs::Log::ConstPtr message_to_constptr(rosgraph_msgs::Log log_message)
-  {
-    return boost::make_shared<rosgraph_msgs::Log const>(log_message);
-  }
-
-  void initialize_log_node(std::shared_ptr<LogNode> & log_node) {
-    std::string log_group = "YjFjMTM5YTEyNzliMjdlNjBlZGY1ZjQy";
-    std::string log_stream = "hZDExYmNmMGJkMjMw";
-    Aws::Client::ClientConfiguration config; 
-    Aws::SDKOptions sdk_options;
-
-    EXPECT_CALL(*log_manager_factory_, 
-        CreateLogManager(StrEq(log_group), StrEq(log_stream), Eq(config), _))
-      .WillOnce(Return(log_manager_));
-
-    log_node->Initialize(log_group, log_stream, config, sdk_options, log_manager_factory_);  
-  }
-};
-
-TEST_F(LogNodeFixture, TestInitialize)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject();
-  initialize_log_node(test_subject); 
-}
-
-TEST_F(LogNodeFixture, TestRecordLogsUninitialized)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject();
-  
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-}
-
-TEST_F(LogNodeFixture, TestRecordLogSevBelowMinSeverity)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR); 
-
-  initialize_log_node(test_subject); 
-
-  ON_CALL(*log_manager_, RecordLog(_))
-    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-  EXPECT_CALL(*log_manager_, RecordLog(_))
-    .Times(0);
-
-  log_message_.level = rosgraph_msgs::Log::DEBUG;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-  log_message_.level = rosgraph_msgs::Log::INFO;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-  log_message_.level = rosgraph_msgs::Log::WARN;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-}
-
-TEST_F(LogNodeFixture, TestRecordLogSevEqGtMinSeverity)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR); 
-
-  initialize_log_node(test_subject); 
-
-  ON_CALL(*log_manager_, RecordLog(_))
-    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-  EXPECT_CALL(*log_manager_, RecordLog(_))
-    .Times(2);
-
-  log_message_.level = rosgraph_msgs::Log::ERROR;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-  log_message_.level = rosgraph_msgs::Log::FATAL;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-}
-
-TEST_F(LogNodeFixture, TestRecordLogTopicsOk)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG);
-
-  initialize_log_node(test_subject); 
-
-  const char* node_name2 = "zNzQwNjU4NWRi";
-  std::ostringstream log_name_reference_stream2; 
-  log_name_reference_stream2 << "[node name: " << node_name2 << "]";
-
-  const char* topic1 = "ZjlkYmUzOTI5ODA0ZT";
-  const char* topic2 = "jNjIxMWRm";
-  std::ostringstream log_topics_reference_stream2; 
-  log_topics_reference_stream2 << "[topics: " << topic1 << ", " << topic2 << "] ";
-
-  {
-    InSequence record_log_seq;
-
-    std::ostringstream log_name_reference_stream1; 
-    log_name_reference_stream1 << "[node name: " << log_message_.name << "]";
-    std::ostringstream log_topics_reference_stream1; 
-    log_topics_reference_stream1 << "[topics: ]";
-  
-    EXPECT_CALL(*log_manager_, 
-      RecordLog(AllOf(
-        HasSubstr("DEBUG"), HasSubstr(log_message_.msg), 
-        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream1.str())
-        )))
-      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED)); 
-    
-    EXPECT_CALL(*log_manager_, 
-      RecordLog(AllOf(
-        HasSubstr("INFO"), HasSubstr(log_message_.msg), 
-        HasSubstr(log_name_reference_stream2.str()), HasSubstr(log_topics_reference_stream1.str())
-        )))
-      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED)); 
-
-    EXPECT_CALL(*log_manager_, 
-      RecordLog(AllOf(
-        HasSubstr("WARN"), HasSubstr(log_message_.msg), 
-        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream2.str())
-        )))
-      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED)); 
-  }
-
-  log_message_.level = rosgraph_msgs::Log::DEBUG;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-
-  rosgraph_msgs::Log log_message2 = log_message_;
-  log_message2.level = rosgraph_msgs::Log::INFO;
-  log_message2.name = node_name2; 
-  test_subject->RecordLogs(message_to_constptr(log_message2));
-
-  rosgraph_msgs::Log log_message3 = log_message_;
-  log_message3.topics.push_back(topic1);
-  log_message3.topics.push_back(topic2);
-  log_message3.level = rosgraph_msgs::Log::WARN;
-  test_subject->RecordLogs(message_to_constptr(log_message3));
-}
-
-TEST_F(LogNodeFixture, TestTriggerLogPublisher)
-{
-  std::shared_ptr<LogNode> test_subject = build_test_subject();
-  initialize_log_node(test_subject); 
-
-  EXPECT_CALL(*log_manager_, Service())
-    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED))
-    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED))
-    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-  
-  ros::TimerEvent event1, event2, event3;
-  test_subject->TriggerLogPublisher(event1);
-  test_subject->TriggerLogPublisher(event2);
-  test_subject->TriggerLogPublisher(event3);
-}
-
-
-TEST_F(LogNodeFixture, TestRecordLogIgnoreList)
-{
-  std::unordered_set<std::string> ignore_nodes;
-  ignore_nodes.emplace(log_message_.name);
-  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG, ignore_nodes);
-
-  initialize_log_node(test_subject);
-
-  ON_CALL(*log_manager_, RecordLog(_))
-    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-  EXPECT_CALL(*log_manager_, RecordLog(_))
-    .Times(0);
-
-  log_message_.level = rosgraph_msgs::Log::INFO;
-  test_subject->RecordLogs(message_to_constptr(log_message_));
-}
+//class LogManagerFactoryMock : public LogManagerFactory
+//{
+//  public:
+//    MOCK_METHOD4(CreateLogManager,
+//      std::shared_ptr<LogBatcher>(
+//        const std::string & log_group, const std::string & log_stream,
+//        const Aws::Client::ClientConfiguration & client_config, const Aws::SDKOptions & sdk_options
+//      )
+//    );
+//};
+//
+//class LogManagerMock : public LogBatcher
+//{
+//public:
+//  LogManagerMock(): LogManager(nullptr) {}
+//
+//  MOCK_METHOD1(RecordLog, ROSCloudWatchLogsErrors(const std::string & log_msg_formatted));
+//  MOCK_METHOD0(Service, ROSCloudWatchLogsErrors());
+//};
+//
+//class LogNodeFixture : public ::testing::Test
+//{
+//protected:
+//  std::shared_ptr<LogManagerMock> log_manager_ = std::make_shared<LogManagerMock>();
+//  std::shared_ptr<LogManagerFactoryMock> log_manager_factory_ = std::make_shared<LogManagerFactoryMock>();
+//
+//  rosgraph_msgs::Log log_message_;
+//
+//  void SetUp() override
+//  {
+//    log_message_.name = "NjhkYjRkZjQ3N2Qw";
+//    log_message_.msg = "ZjQxOGE2MWM5MTFkMWNjMDVkMGY2OTZm";
+//    log_message_.level = rosgraph_msgs::Log::DEBUG;
+//  }
+//
+//  std::shared_ptr<LogNode> build_test_subject(int8_t severity_level = rosgraph_msgs::Log::DEBUG,
+//      std::unordered_set<std::string> ignore_nodes = std::unordered_set<std::string>())
+//  {
+//    return std::make_shared<LogNode>(severity_level, ignore_nodes);
+//  }
+//
+//  rosgraph_msgs::Log::ConstPtr message_to_constptr(rosgraph_msgs::Log log_message)
+//  {
+//    return boost::make_shared<rosgraph_msgs::Log const>(log_message);
+//  }
+//
+//  void initialize_log_node(std::shared_ptr<LogNode> & log_node) {
+//    std::string log_group = "YjFjMTM5YTEyNzliMjdlNjBlZGY1ZjQy";
+//    std::string log_stream = "hZDExYmNmMGJkMjMw";
+//    Aws::Client::ClientConfiguration config;
+//    Aws::SDKOptions sdk_options;
+//
+//    EXPECT_CALL(*log_manager_factory_,
+//        CreateLogManager(StrEq(log_group), StrEq(log_stream), Eq(config), _))
+//      .WillOnce(Return(log_manager_));
+//
+//    log_node->Initialize(log_group, log_stream, config, sdk_options, log_manager_factory_);
+//  }
+//};
+//
+//TEST_F(LogNodeFixture, TestInitialize)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject();
+//  initialize_log_node(test_subject);
+//}
+//
+//TEST_F(LogNodeFixture, TestRecordLogsUninitialized)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject();
+//
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//}
+//
+//TEST_F(LogNodeFixture, TestRecordLogSevBelowMinSeverity)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
+//
+//  initialize_log_node(test_subject);
+//
+//  ON_CALL(*log_manager_, RecordLog(_))
+//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//  EXPECT_CALL(*log_manager_, RecordLog(_))
+//    .Times(0);
+//
+//  log_message_.level = rosgraph_msgs::Log::DEBUG;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//  log_message_.level = rosgraph_msgs::Log::INFO;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//  log_message_.level = rosgraph_msgs::Log::WARN;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//}
+//
+//TEST_F(LogNodeFixture, TestRecordLogSevEqGtMinSeverity)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
+//
+//  initialize_log_node(test_subject);
+//
+//  ON_CALL(*log_manager_, RecordLog(_))
+//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//  EXPECT_CALL(*log_manager_, RecordLog(_))
+//    .Times(2);
+//
+//  log_message_.level = rosgraph_msgs::Log::ERROR;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//  log_message_.level = rosgraph_msgs::Log::FATAL;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//}
+//
+//TEST_F(LogNodeFixture, TestRecordLogTopicsOk)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG);
+//
+//  initialize_log_node(test_subject);
+//
+//  const char* node_name2 = "zNzQwNjU4NWRi";
+//  std::ostringstream log_name_reference_stream2;
+//  log_name_reference_stream2 << "[node name: " << node_name2 << "]";
+//
+//  const char* topic1 = "ZjlkYmUzOTI5ODA0ZT";
+//  const char* topic2 = "jNjIxMWRm";
+//  std::ostringstream log_topics_reference_stream2;
+//  log_topics_reference_stream2 << "[topics: " << topic1 << ", " << topic2 << "] ";
+//
+//  {
+//    InSequence record_log_seq;
+//
+//    std::ostringstream log_name_reference_stream1;
+//    log_name_reference_stream1 << "[node name: " << log_message_.name << "]";
+//    std::ostringstream log_topics_reference_stream1;
+//    log_topics_reference_stream1 << "[topics: ]";
+//
+//    EXPECT_CALL(*log_manager_,
+//      RecordLog(AllOf(
+//        HasSubstr("DEBUG"), HasSubstr(log_message_.msg),
+//        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream1.str())
+//        )))
+//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//
+//    EXPECT_CALL(*log_manager_,
+//      RecordLog(AllOf(
+//        HasSubstr("INFO"), HasSubstr(log_message_.msg),
+//        HasSubstr(log_name_reference_stream2.str()), HasSubstr(log_topics_reference_stream1.str())
+//        )))
+//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//
+//    EXPECT_CALL(*log_manager_,
+//      RecordLog(AllOf(
+//        HasSubstr("WARN"), HasSubstr(log_message_.msg),
+//        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream2.str())
+//        )))
+//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//  }
+//
+//  log_message_.level = rosgraph_msgs::Log::DEBUG;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//
+//  rosgraph_msgs::Log log_message2 = log_message_;
+//  log_message2.level = rosgraph_msgs::Log::INFO;
+//  log_message2.name = node_name2;
+//  test_subject->RecordLogs(message_to_constptr(log_message2));
+//
+//  rosgraph_msgs::Log log_message3 = log_message_;
+//  log_message3.topics.push_back(topic1);
+//  log_message3.topics.push_back(topic2);
+//  log_message3.level = rosgraph_msgs::Log::WARN;
+//  test_subject->RecordLogs(message_to_constptr(log_message3));
+//}
+//
+//TEST_F(LogNodeFixture, TestTriggerLogPublisher)
+//{
+//  std::shared_ptr<LogNode> test_subject = build_test_subject();
+//  initialize_log_node(test_subject);
+//
+//  EXPECT_CALL(*log_manager_, Service())
+//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED))
+//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED))
+//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//
+//  ros::TimerEvent event1, event2, event3;
+//  test_subject->TriggerLogPublisher(event1);
+//  test_subject->TriggerLogPublisher(event2);
+//  test_subject->TriggerLogPublisher(event3);
+//}
+//
+//
+//TEST_F(LogNodeFixture, TestRecordLogIgnoreList)
+//{
+//  std::unordered_set<std::string> ignore_nodes;
+//  ignore_nodes.emplace(log_message_.name);
+//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG, ignore_nodes);
+//
+//  initialize_log_node(test_subject);
+//
+//  ON_CALL(*log_manager_, RecordLog(_))
+//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
+//  EXPECT_CALL(*log_manager_, RecordLog(_))
+//    .Times(0);
+//
+//  log_message_.level = rosgraph_msgs::Log::INFO;
+//  test_subject->RecordLogs(message_to_constptr(log_message_));
+//}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
This merge adds support for offline logs, i.e., the ability to save log data in the event of upload failures to disk and attempt to upload it later.

This depends on https://github.com/aws-robotics/cloudwatch-common/tree/offline-logs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.