### PR TITLE
Restored unit tests

### DIFF
--- a/cloudwatch_logger/test/log_node_test.cpp
+++ b/cloudwatch_logger/test/log_node_test.cpp
@@ -17,7 +17,9 @@
 #include <gmock/gmock.h>
 
 #include <cloudwatch_logger/log_node.h>
+#include <cloudwatch_logs_common/log_service.h>
 #include <cloudwatch_logs_common/log_batcher.h>
+#include <cloudwatch_logs_common/log_publisher.h>
 #include <cloudwatch_logs_common/log_service_factory.h>
 #include <rosgraph_msgs/Log.h>
 
@@ -31,208 +33,269 @@ using ::testing::StrEq;
 using ::testing::Eq;
 using ::testing::InSequence;
 
-//class LogManagerFactoryMock : public LogManagerFactory
-//{
-//  public:
-//    MOCK_METHOD4(CreateLogManager,
-//      std::shared_ptr<LogBatcher>(
-//        const std::string & log_group, const std::string & log_stream,
-//        const Aws::Client::ClientConfiguration & client_config, const Aws::SDKOptions & sdk_options
-//      )
-//    );
-//};
-//
-//class LogManagerMock : public LogBatcher
-//{
-//public:
-//  LogManagerMock(): LogManager(nullptr) {}
-//
-//  MOCK_METHOD1(RecordLog, ROSCloudWatchLogsErrors(const std::string & log_msg_formatted));
-//  MOCK_METHOD0(Service, ROSCloudWatchLogsErrors());
-//};
-//
-//class LogNodeFixture : public ::testing::Test
-//{
-//protected:
-//  std::shared_ptr<LogManagerMock> log_manager_ = std::make_shared<LogManagerMock>();
-//  std::shared_ptr<LogManagerFactoryMock> log_manager_factory_ = std::make_shared<LogManagerFactoryMock>();
-//
-//  rosgraph_msgs::Log log_message_;
-//
-//  void SetUp() override
-//  {
-//    log_message_.name = "NjhkYjRkZjQ3N2Qw";
-//    log_message_.msg = "ZjQxOGE2MWM5MTFkMWNjMDVkMGY2OTZm";
-//    log_message_.level = rosgraph_msgs::Log::DEBUG;
-//  }
-//
-//  std::shared_ptr<LogNode> build_test_subject(int8_t severity_level = rosgraph_msgs::Log::DEBUG,
-//      std::unordered_set<std::string> ignore_nodes = std::unordered_set<std::string>())
-//  {
-//    return std::make_shared<LogNode>(severity_level, ignore_nodes);
-//  }
-//
-//  rosgraph_msgs::Log::ConstPtr message_to_constptr(rosgraph_msgs::Log log_message)
-//  {
-//    return boost::make_shared<rosgraph_msgs::Log const>(log_message);
-//  }
-//
-//  void initialize_log_node(std::shared_ptr<LogNode> & log_node) {
-//    std::string log_group = "YjFjMTM5YTEyNzliMjdlNjBlZGY1ZjQy";
-//    std::string log_stream = "hZDExYmNmMGJkMjMw";
-//    Aws::Client::ClientConfiguration config;
-//    Aws::SDKOptions sdk_options;
-//
-//    EXPECT_CALL(*log_manager_factory_,
-//        CreateLogManager(StrEq(log_group), StrEq(log_stream), Eq(config), _))
-//      .WillOnce(Return(log_manager_));
-//
-//    log_node->Initialize(log_group, log_stream, config, sdk_options, log_manager_factory_);
-//  }
-//};
-//
-//TEST_F(LogNodeFixture, TestInitialize)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject();
-//  initialize_log_node(test_subject);
-//}
-//
-//TEST_F(LogNodeFixture, TestRecordLogsUninitialized)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject();
-//
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//}
-//
-//TEST_F(LogNodeFixture, TestRecordLogSevBelowMinSeverity)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
-//
-//  initialize_log_node(test_subject);
-//
-//  ON_CALL(*log_manager_, RecordLog(_))
-//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//  EXPECT_CALL(*log_manager_, RecordLog(_))
-//    .Times(0);
-//
-//  log_message_.level = rosgraph_msgs::Log::DEBUG;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//  log_message_.level = rosgraph_msgs::Log::INFO;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//  log_message_.level = rosgraph_msgs::Log::WARN;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//}
-//
-//TEST_F(LogNodeFixture, TestRecordLogSevEqGtMinSeverity)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
-//
-//  initialize_log_node(test_subject);
-//
-//  ON_CALL(*log_manager_, RecordLog(_))
-//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//  EXPECT_CALL(*log_manager_, RecordLog(_))
-//    .Times(2);
-//
-//  log_message_.level = rosgraph_msgs::Log::ERROR;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//  log_message_.level = rosgraph_msgs::Log::FATAL;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//}
-//
-//TEST_F(LogNodeFixture, TestRecordLogTopicsOk)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG);
-//
-//  initialize_log_node(test_subject);
-//
-//  const char* node_name2 = "zNzQwNjU4NWRi";
-//  std::ostringstream log_name_reference_stream2;
-//  log_name_reference_stream2 << "[node name: " << node_name2 << "]";
-//
-//  const char* topic1 = "ZjlkYmUzOTI5ODA0ZT";
-//  const char* topic2 = "jNjIxMWRm";
-//  std::ostringstream log_topics_reference_stream2;
-//  log_topics_reference_stream2 << "[topics: " << topic1 << ", " << topic2 << "] ";
-//
-//  {
-//    InSequence record_log_seq;
-//
-//    std::ostringstream log_name_reference_stream1;
-//    log_name_reference_stream1 << "[node name: " << log_message_.name << "]";
-//    std::ostringstream log_topics_reference_stream1;
-//    log_topics_reference_stream1 << "[topics: ]";
-//
-//    EXPECT_CALL(*log_manager_,
-//      RecordLog(AllOf(
-//        HasSubstr("DEBUG"), HasSubstr(log_message_.msg),
-//        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream1.str())
-//        )))
-//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//
-//    EXPECT_CALL(*log_manager_,
-//      RecordLog(AllOf(
-//        HasSubstr("INFO"), HasSubstr(log_message_.msg),
-//        HasSubstr(log_name_reference_stream2.str()), HasSubstr(log_topics_reference_stream1.str())
-//        )))
-//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//
-//    EXPECT_CALL(*log_manager_,
-//      RecordLog(AllOf(
-//        HasSubstr("WARN"), HasSubstr(log_message_.msg),
-//        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream2.str())
-//        )))
-//      .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//  }
-//
-//  log_message_.level = rosgraph_msgs::Log::DEBUG;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//
-//  rosgraph_msgs::Log log_message2 = log_message_;
-//  log_message2.level = rosgraph_msgs::Log::INFO;
-//  log_message2.name = node_name2;
-//  test_subject->RecordLogs(message_to_constptr(log_message2));
-//
-//  rosgraph_msgs::Log log_message3 = log_message_;
-//  log_message3.topics.push_back(topic1);
-//  log_message3.topics.push_back(topic2);
-//  log_message3.level = rosgraph_msgs::Log::WARN;
-//  test_subject->RecordLogs(message_to_constptr(log_message3));
-//}
-//
-//TEST_F(LogNodeFixture, TestTriggerLogPublisher)
-//{
-//  std::shared_ptr<LogNode> test_subject = build_test_subject();
-//  initialize_log_node(test_subject);
-//
-//  EXPECT_CALL(*log_manager_, Service())
-//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED))
-//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED))
-//    .WillOnce(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//
-//  ros::TimerEvent event1, event2, event3;
-//  test_subject->TriggerLogPublisher(event1);
-//  test_subject->TriggerLogPublisher(event2);
-//  test_subject->TriggerLogPublisher(event3);
-//}
-//
-//
-//TEST_F(LogNodeFixture, TestRecordLogIgnoreList)
-//{
-//  std::unordered_set<std::string> ignore_nodes;
-//  ignore_nodes.emplace(log_message_.name);
-//  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG, ignore_nodes);
-//
-//  initialize_log_node(test_subject);
-//
-//  ON_CALL(*log_manager_, RecordLog(_))
-//    .WillByDefault(Return(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED));
-//  EXPECT_CALL(*log_manager_, RecordLog(_))
-//    .Times(0);
-//
-//  log_message_.level = rosgraph_msgs::Log::INFO;
-//  test_subject->RecordLogs(message_to_constptr(log_message_));
-//}
+class LogServiceFactoryMock : public LogServiceFactory
+{
+  public:
+    MOCK_METHOD5(CreateLogService,
+      std::shared_ptr<LogService>(
+        const std::string & log_group,
+        const std::string & log_stream,
+        const Aws::Client::ClientConfiguration & client_config,
+        const Aws::SDKOptions & sdk_options,
+        const CloudWatchOptions & cloudwatch_option
+      )
+    );
+};
+
+class LogBatcherMock : public LogBatcher
+{
+public:
+
+  MOCK_METHOD0(publishBatchedData, bool());
+};
+
+class LogPublisherMock : public LogPublisher
+{
+public:
+    LogPublisherMock(const std::string & log_group,
+                     const std::string & log_stream,
+                     const Aws::Client::ClientConfiguration & client_config)
+                      : LogPublisher(log_group, log_stream, client_config) {}
+};
+
+class LogServiceMock : public LogService
+{
+public:
+    LogServiceMock(std::shared_ptr<Publisher<LogCollection>> log_publisher,
+               std::shared_ptr<DataBatcher<LogType>> log_batcher,
+               std::shared_ptr<FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
+               : LogService(log_publisher, log_batcher, log_file_upload_streamer) {}
+
+    MOCK_METHOD1(batchData, bool(const std::string & data_to_batch));
+    MOCK_METHOD0(start, bool());
+    MOCK_METHOD0(shutdown, bool());
+    MOCK_METHOD0(publishBatchedData, bool());
+};
+
+class LogNodeFixture : public ::testing::Test
+{
+protected:
+
+  std::shared_ptr<LogServiceMock> log_service;
+  std::shared_ptr<LogServiceFactoryMock> log_service_factory;
+  std::shared_ptr<LogBatcherMock> log_batcher;
+  std::shared_ptr<LogPublisherMock> log_publisher;
+  std::shared_ptr<LogNode> log_node;
+
+  rosgraph_msgs::Log log_message_;
+
+  void SetUp() override
+  {
+    log_message_.name = "NjhkYjRkZjQ3N2Qw";
+    log_message_.msg = "ZjQxOGE2MWM5MTFkMWNjMDVkMGY2OTZm";
+    log_message_.level = rosgraph_msgs::Log::DEBUG;
+    Aws::Client::ClientConfiguration config;
+
+    log_publisher = std::make_shared<LogPublisherMock>(
+            std::string("test_group"), std::string("test_stream"), config);
+    log_batcher = std::make_shared<LogBatcherMock>();
+    log_service = std::make_shared<LogServiceMock>(log_publisher, log_batcher);
+    log_service_factory = std::make_shared<LogServiceFactoryMock>();
+  }
+
+  std::shared_ptr<LogNode> build_test_subject(int8_t severity_level = rosgraph_msgs::Log::DEBUG,
+      std::unordered_set<std::string> ignore_nodes = std::unordered_set<std::string>())
+  {
+    return std::make_shared<LogNode>(severity_level, ignore_nodes);
+  }
+
+  rosgraph_msgs::Log::ConstPtr message_to_constptr(rosgraph_msgs::Log log_message)
+  {
+    return boost::make_shared<rosgraph_msgs::Log const>(log_message);
+  }
+
+  void initialize_log_node(std::shared_ptr<LogNode> & ln) {
+
+    log_node = ln;
+
+    std::string log_group = "YjFjMTM5YTEyNzliMjdlNjBlZGY1ZjQy";
+    std::string log_stream = "hZDExYmNmMGJkMjMw";
+    Aws::Client::ClientConfiguration config;
+    Aws::SDKOptions sdk_options;
+    Aws::CloudWatchLogs::CloudWatchOptions cloudwatch_options;
+
+    EXPECT_CALL(*log_service_factory,
+        CreateLogService(StrEq(log_group), StrEq(log_stream), Eq(config), _, _))
+      .WillOnce(Return(log_service));
+
+    log_node->Initialize(log_group, log_stream, config, sdk_options, cloudwatch_options, log_service_factory);
+
+    EXPECT_CALL(*log_service, start()).Times(1);
+
+    log_node->start();
+  }
+
+  void TearDown() override {
+
+    if(log_node) {
+
+      EXPECT_CALL(*log_service, shutdown()).Times(1);
+      log_node->shutdown();
+    }
+  }
+};
+
+TEST_F(LogNodeFixture, TestInitialize)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject();
+  initialize_log_node(test_subject);
+}
+
+TEST_F(LogNodeFixture, TestRecordLogsUninitialized)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject();
+
+  EXPECT_CALL(*log_service, batchData(_)).Times(0);
+  EXPECT_CALL(*log_service, start()).Times(0);
+
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+}
+
+TEST_F(LogNodeFixture, TestRecordLogsInitialized)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject();
+
+  EXPECT_CALL(*log_service, batchData(_)).Times(1);
+
+  initialize_log_node(test_subject);
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+}
+
+TEST_F(LogNodeFixture, TestRecordLogSevBelowMinSeverity)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
+
+  initialize_log_node(test_subject);
+
+  ON_CALL(*log_service, batchData(_))
+  .WillByDefault(Return(true));
+  EXPECT_CALL(*log_service, batchData(_))
+  .Times(0);
+
+  log_message_.level = rosgraph_msgs::Log::DEBUG;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+  log_message_.level = rosgraph_msgs::Log::INFO;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+  log_message_.level = rosgraph_msgs::Log::WARN;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+}
+
+TEST_F(LogNodeFixture, TestRecordLogSevEqGtMinSeverity)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::ERROR);
+
+  initialize_log_node(test_subject);
+
+  ON_CALL(*log_service, batchData(_))
+    .WillByDefault(Return(true));
+  EXPECT_CALL(*log_service, batchData(_))
+    .Times(2);
+
+  log_message_.level = rosgraph_msgs::Log::ERROR;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+  log_message_.level = rosgraph_msgs::Log::FATAL;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+
+  ON_CALL(*log_service, publishBatchedData())
+  .WillByDefault(Return(true));
+  EXPECT_CALL(*log_service, publishBatchedData())
+  .Times(1);
+
+  // this is usually called by a timer, manually test
+  ros::TimerEvent timer_event;
+  test_subject->TriggerLogPublisher(timer_event);
+}
+
+TEST_F(LogNodeFixture, TestRecordLogTopicsOk)
+{
+  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG);
+
+  initialize_log_node(test_subject);
+
+  const char* node_name2 = "zNzQwNjU4NWRi";
+  std::ostringstream log_name_reference_stream2;
+  log_name_reference_stream2 << "[node name: " << node_name2 << "]";
+
+  const char* topic1 = "ZjlkYmUzOTI5ODA0ZT";
+  const char* topic2 = "jNjIxMWRm";
+  std::ostringstream log_topics_reference_stream2;
+  log_topics_reference_stream2 << "[topics: " << topic1 << ", " << topic2 << "] ";
+
+  {
+    InSequence record_log_seq;
+
+    std::ostringstream log_name_reference_stream1;
+    log_name_reference_stream1 << "[node name: " << log_message_.name << "]";
+    std::ostringstream log_topics_reference_stream1;
+    log_topics_reference_stream1 << "[topics: ]";
+
+    EXPECT_CALL(*log_service,
+      batchData(AllOf(
+        HasSubstr("DEBUG"), HasSubstr(log_message_.msg),
+        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream1.str())
+        )))
+      .WillOnce(Return(true));
+
+    EXPECT_CALL(*log_service,
+            batchData(AllOf(
+        HasSubstr("INFO"), HasSubstr(log_message_.msg),
+        HasSubstr(log_name_reference_stream2.str()), HasSubstr(log_topics_reference_stream1.str())
+        )))
+      .WillOnce(Return(true));
+
+    EXPECT_CALL(*log_service,
+            batchData(AllOf(
+        HasSubstr("WARN"), HasSubstr(log_message_.msg),
+        HasSubstr(log_name_reference_stream1.str()), HasSubstr(log_topics_reference_stream2.str())
+        )))
+      .WillOnce(Return(true));
+  }
+
+  log_message_.level = rosgraph_msgs::Log::DEBUG;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+
+  rosgraph_msgs::Log log_message2 = log_message_;
+  log_message2.level = rosgraph_msgs::Log::INFO;
+  log_message2.name = node_name2;
+  test_subject->RecordLogs(message_to_constptr(log_message2));
+
+  rosgraph_msgs::Log log_message3 = log_message_;
+  log_message3.topics.push_back(topic1);
+  log_message3.topics.push_back(topic2);
+  log_message3.level = rosgraph_msgs::Log::WARN;
+  test_subject->RecordLogs(message_to_constptr(log_message3));
+}
+
+TEST_F(LogNodeFixture, TestRecordLogIgnoreList)
+{
+  std::unordered_set<std::string> ignore_nodes;
+  ignore_nodes.emplace(log_message_.name);
+  std::shared_ptr<LogNode> test_subject = build_test_subject(rosgraph_msgs::Log::DEBUG, ignore_nodes);
+
+  initialize_log_node(test_subject);
+
+  ON_CALL(*log_service, batchData(_))
+    .WillByDefault(Return(true));
+  EXPECT_CALL(*log_service, batchData(_))
+    .Times(0);
+
+  log_message_.level = rosgraph_msgs::Log::INFO;
+  test_subject->RecordLogs(message_to_constptr(log_message_));
+}
+
+TEST_F(LogNodeFixture, Sanity) {
+  ASSERT_TRUE(true);
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
Restored unit tests that were previously commented out due to changes introduced by the offline caching feature.

Tests pass with the following gtest flags: --gtest_shuffle --gtest_repeat=1000

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
