### PR TITLE
Fix linting issues found by clang-tidy 6.0

### DIFF
--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -62,7 +62,7 @@ public:
   /**
    *  @brief Tears down a AWSCloudWatchLogNode object
    */
-  ~LogNode();
+  ~LogNode() override;
 
   /**
    * @brief Reads creds, region, and SDK option to configure log manager
@@ -76,7 +76,7 @@ public:
   void Initialize(const std::string & log_group, const std::string & log_stream,
                   const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
                   const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
-                  std::shared_ptr<LogServiceFactory> log_service_factory = std::make_shared<LogServiceFactory>());
+                  const std::shared_ptr<LogServiceFactory>& log_service_factory = std::make_shared<LogServiceFactory>());
 
   bool start() override;
   bool shutdown() override;

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node.h
@@ -34,8 +34,16 @@ class LogNode : public Service
 {
 public:
   struct Options {
-    int8_t min_log_severity;
-    bool publish_topic_names;
+    Options() = default;
+
+    template<class UnorderedSet>
+    Options(int8_t severity, bool publish, UnorderedSet && nodes)
+      : min_log_severity(severity),
+        publish_topic_names(publish),
+        ignore_nodes(std::forward<UnorderedSet>(nodes)) {}
+
+    int8_t min_log_severity = rosgraph_msgs::Log::DEBUG;
+    bool publish_topic_names = true;
     std::unordered_set<std::string> ignore_nodes;
   };
 
@@ -94,7 +102,7 @@ public:
    *
    * @param timer A ros timer
    */
-  void TriggerLogPublisher(const ros::TimerEvent &);
+  void TriggerLogPublisher(const ros::TimerEvent & /*unused*/);
 
   /**
    * Return a Trigger response detailing the LogService online status.

--- a/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
+++ b/cloudwatch_logger/include/cloudwatch_logger/log_node_param_helper.h
@@ -69,7 +69,7 @@ constexpr bool kNodePublishTopicNamesDefaultValue = true;
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadPublishFrequency(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   double & publish_frequency);
 
 /**
@@ -80,7 +80,7 @@ Aws::AwsError ReadPublishFrequency(
  * @return an error code that indicates whether the parameter was read successfully or not, 
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogGroup(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                            std::string & log_group);
 
 /**
@@ -91,7 +91,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
  * @return an error code that indicates whether the parameter was read successfully or not, 
  * as returned by \p parameter_reader
  */
-Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogStream(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                             std::string & log_stream);
 
 /**
@@ -103,7 +103,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadSubscribeToRosout(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   bool & subscribe_to_rosout);
 
 /**
@@ -116,7 +116,7 @@ Aws::AwsError ReadSubscribeToRosout(
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadMinLogVerbosity(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   int8_t & min_log_verbosity);
 
 /**
@@ -146,8 +146,8 @@ Aws::AwsError ReadPublishTopicNames(
  */
 Aws::AwsError ReadSubscriberList(
   bool subscribe_to_rosout,
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  boost::function<void(const rosgraph_msgs::Log::ConstPtr &)> callback,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
+  const boost::function<void(const rosgraph_msgs::Log::ConstPtr &)>& callback,
   ros::NodeHandle & nh,
   std::vector<ros::Subscriber> & subscriptions);
   
@@ -160,7 +160,7 @@ Aws::AwsError ReadSubscriberList(
  * as returned by \p parameter_reader
  */
 Aws::AwsError ReadIgnoreNodesSet(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::unordered_set<std::string> & ignore_nodes);
 
 /**
@@ -172,7 +172,7 @@ Aws::AwsError ReadIgnoreNodesSet(
  * as returned by \p parameter_reader
  */
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options);
 
 /**
@@ -184,7 +184,7 @@ void ReadCloudWatchOptions(
  * as returned by \p parameter_reader
  */
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options);
 
 /**
@@ -196,7 +196,7 @@ void ReadUploaderOptions(
  * as returned by \p parameter_reader
  */
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options);
 
 /**
@@ -210,7 +210,7 @@ void ReadFileManagerStrategyOptions(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value);
@@ -226,7 +226,7 @@ void ReadOption(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -28,7 +28,10 @@
 #include <std_srvs/Trigger.h>
 #include <std_srvs/Empty.h>
 
-using namespace Aws::CloudWatchLogs::Utils;
+
+namespace Aws {
+namespace CloudWatchLogs {
+namespace Utils {
 
 LogNode::LogNode(const Options & options)
   : min_log_severity_(options.min_log_severity),
@@ -36,7 +39,7 @@ LogNode::LogNode(const Options & options)
     publish_topic_names_(options.publish_topic_names) {}
 
 LogNode::LogNode(int8_t min_log_severity, std::unordered_set<std::string> ignore_nodes)
-  : LogNode(Options{min_log_severity, true, std::move(ignore_nodes)}) {}
+  : LogNode(Options(min_log_severity, true, std::move(ignore_nodes))) {}
 
 LogNode::~LogNode() { this->log_service_ = nullptr; }
 
@@ -96,7 +99,7 @@ void LogNode::RecordLogs(const rosgraph_msgs::Log::ConstPtr & log_msg)
   }
 }
 
-void LogNode::TriggerLogPublisher(const ros::TimerEvent &) {
+void LogNode::TriggerLogPublisher(const ros::TimerEvent & /*unused*/) {
   this->log_service_->publishBatchedData();
 }
 
@@ -149,3 +152,7 @@ const std::string LogNode::FormatLogs(const rosgraph_msgs::Log::ConstPtr & log_m
 
   return ss.str();
 }
+
+}  // namespace Utils
+}  // namespace CloudWatchLogs
+}  // namespace Aws

--- a/cloudwatch_logger/src/log_node.cpp
+++ b/cloudwatch_logger/src/log_node.cpp
@@ -43,7 +43,7 @@ LogNode::~LogNode() { this->log_service_ = nullptr; }
 void LogNode::Initialize(const std::string & log_group, const std::string & log_stream,
                          const Aws::Client::ClientConfiguration & config, Aws::SDKOptions & sdk_options,
                          const Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options,
-                         std::shared_ptr<LogServiceFactory> factory)
+                         const std::shared_ptr<LogServiceFactory>& factory)
 {
   this->log_service_ = factory->CreateLogService(log_group, log_stream, config, sdk_options, cloudwatch_options);
 }

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -18,8 +18,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <cloudwatch_logs_common/cloudwatch_options.h>
 
-
-using namespace Aws::Client;
+using Aws::Client::ParameterPath;
 
 namespace Aws {
 namespace CloudWatchLogs {

--- a/cloudwatch_logger/src/log_node_param_helper.cpp
+++ b/cloudwatch_logger/src/log_node_param_helper.cpp
@@ -26,7 +26,7 @@ namespace CloudWatchLogs {
 namespace Utils {
 
 Aws::AwsError ReadPublishFrequency(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   double & publish_frequency)
 {
   Aws::AwsError ret =
@@ -51,7 +51,7 @@ Aws::AwsError ReadPublishFrequency(
   return ret;
 }
 
-Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogGroup(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                            std::string & log_group)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogGroupNameKey), log_group);
@@ -74,7 +74,7 @@ Aws::AwsError ReadLogGroup(std::shared_ptr<Aws::Client::ParameterReaderInterface
   return ret;
 }
 
-Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+Aws::AwsError ReadLogStream(const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
                             std::string & log_stream)
 {
   Aws::AwsError ret = parameter_reader->ReadParam(ParameterPath(kNodeParamLogStreamNameKey), log_stream);
@@ -98,7 +98,7 @@ Aws::AwsError ReadLogStream(std::shared_ptr<Aws::Client::ParameterReaderInterfac
 }
 
 Aws::AwsError ReadSubscribeToRosout(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   bool & subscribe_to_rosout)
 {
   Aws::AwsError ret =
@@ -127,7 +127,7 @@ Aws::AwsError ReadSubscribeToRosout(
 }
 
 Aws::AwsError ReadMinLogVerbosity(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   int8_t & min_log_verbosity)
 {
   min_log_verbosity = kNodeMinLogVerbosityDefaultValue;
@@ -204,8 +204,8 @@ Aws::AwsError ReadPublishTopicNames(
 
 Aws::AwsError ReadSubscriberList(
   const bool subscribe_to_rosout,
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  boost::function<void(const rosgraph_msgs::Log::ConstPtr &)> callback,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
+  const boost::function<void(const rosgraph_msgs::Log::ConstPtr &)>& callback,
   ros::NodeHandle & nh,
   std::vector<ros::Subscriber> & subscriptions)
 {
@@ -226,7 +226,7 @@ Aws::AwsError ReadSubscriberList(
 }
 
 Aws::AwsError ReadIgnoreNodesSet(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   std::unordered_set<std::string> & ignore_nodes)
 {
   std::vector<std::string> ignore_list;
@@ -248,10 +248,10 @@ Aws::AwsError ReadIgnoreNodesSet(
 }
 
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchLogs::CloudWatchOptions & cloudwatch_options) {
 
-  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::DataFlow::UploaderOptions uploader_options{};
   Aws::FileManagement::FileManagerStrategyOptions file_manager_strategy_options;
 
   ReadUploaderOptions(parameter_reader, uploader_options);
@@ -264,7 +264,7 @@ void ReadCloudWatchOptions(
 }
 
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options) {
 
   ReadOption(
@@ -304,7 +304,7 @@ void ReadUploaderOptions(
 }
 
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options) {
 
   ReadOption(
@@ -339,7 +339,7 @@ void ReadFileManagerStrategyOptions(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value) {
@@ -361,7 +361,7 @@ void ReadOption(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value) {
@@ -374,7 +374,7 @@ void ReadOption(
                          option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
-      option_value = (size_t)return_value;
+      option_value = static_cast<size_t>(return_value);
       AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:

--- a/cloudwatch_logger/test/log_node_param_helper_test.cpp
+++ b/cloudwatch_logger/test/log_node_param_helper_test.cpp
@@ -21,7 +21,6 @@
 
 using namespace Aws::Client;
 using namespace Aws::CloudWatchLogs::Utils;
-using ::testing::_;
 using ::testing::Eq;
 using ::testing::A;
 using ::testing::InSequence;

--- a/cloudwatch_logger/test/log_node_test.cpp
+++ b/cloudwatch_logger/test/log_node_test.cpp
@@ -23,6 +23,8 @@
 #include <cloudwatch_logs_common/log_service_factory.h>
 #include <rosgraph_msgs/Log.h>
 
+#include <utility>
+
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::CloudWatchLogs::Utils;
 using ::testing::_;
@@ -69,7 +71,7 @@ public:
     LogServiceMock(std::shared_ptr<Publisher<LogCollection>> log_publisher,
                std::shared_ptr<DataBatcher<LogType>> log_batcher,
                std::shared_ptr<FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
-               : LogService(log_publisher, log_batcher, log_file_upload_streamer) {}
+               : LogService(std::move(log_publisher), std::move(log_batcher), std::move(log_file_upload_streamer)) {}
 
     MOCK_METHOD1(batchData, bool(const std::string & data_to_batch));
     MOCK_METHOD0(start, bool());

--- a/cloudwatch_logger/test/log_node_test.cpp
+++ b/cloudwatch_logger/test/log_node_test.cpp
@@ -27,6 +27,7 @@
 
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::CloudWatchLogs::Utils;
+using namespace Aws::FileManagement;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::HasSubstr;


### PR DESCRIPTION
*Description of changes:*

Fixing linting issues found by `clang-tidy` 6.0, without introducing public API changes (there may be ABI changes though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.