### PR TITLE
Update README to list required IAM permission: logs:DescribeLogGroups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You will need to create an AWS Account and configure the credentials to be able 
 
 This node will require the following AWS account IAM role permissions:
 - `logs:PutLogEvents`
+- `logs:DescribeLogGroups`
 - `logs:DescribeLogStreams`
 - `logs:CreateLogStream`
 - `logs:CreateLogGroup`


### PR DESCRIPTION
This change updates the `README.md` to mention the requirement of IAM role permission: `logs:DescribeLogGroups`.
The permission logs:DescribeLogGroups is used by aws_common to list CloudWatch log groups to determine if the log group used by cloudwatch_logger exists.

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
